### PR TITLE
CMake detects compiler configuration automatically.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,19 @@ macro (add_definitions_unless ENV_VAL DEF_VAL)
   endif ()
 endmacro (add_definitions_unless)
 
+function (check_mpi_compiler COMPILER_NAME RESULT)
+  get_filename_component(COMPILER_NAME ${COMPILER_NAME} NAME)
+  string(LENGTH ${COMPILER_NAME} NAME_LEN)
+  if (${NAME_LEN} LESS 3)
+    set(RET false)
+  else ()
+    string(SUBSTRING ${COMPILER_NAME} 0 3 COMPILER_HEADER)
+    string(TOLOWER ${COMPILER_HEADER} COMPILER_HEADER)
+    string(COMPARE EQUAL ${COMPILER_HEADER} "mpi" RET)
+  endif ()
+  set(${RESULT} ${RET} PARENT_SCOPE)
+endfunction (check_mpi_compiler)
+
 
 ### Set target
 set_unless_def(BUILD_TARGET  "sc")
@@ -41,11 +54,54 @@ endif ()
 ### Project settings
 project(ARTED Fortran C)
 
-message(STATUS "Target platform ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
+if (${CMAKE_CROSSCOMPILING})
+  message(STATUS "Target platform ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
+else ()
+  message(STATUS "Target platform is Native (${CMAKE_HOST_SYSTEM})")
+
+  set(TARGET_SUFFIX ".cpu")
+
+  check_mpi_compiler(${CMAKE_Fortran_COMPILER} IS_MPI_COMPILER)
+  if (${IS_MPI_COMPILER})
+    set(MPI_Fortran_COMPILER ${CMAKE_Fortran_COMPILER})
+  endif ()
+
+  check_mpi_compiler(${CMAKE_C_COMPILER} IS_MPI_COMPILER)
+  if (${IS_MPI_COMPILER})
+    set(MPI_C_COMPILER ${CMAKE_C_COMPILER})
+  endif ()
+
+  find_package(MPI REQUIRED)
+
+  if (NOT DEFINED MPI_Fortran_FOUND)
+    message(FATAL_ERROR "MPI Fortran compilers not found.")
+  endif()
+
+  if (NOT DEFINED MPI_C_FOUND)
+    message(FATAL_ERROR "MPI C compilers not found.")
+  endif()
+
+  set(CMAKE_Fortran_COMPILER ${MPI_Fortran_COMPILER})
+  set(CMAKE_C_COMPILER ${MPI_C_COMPILER})
+
+  set(CMAKE_Fortran_FLAGS_DEBUG   "-O2 -g")
+  set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+  set(Fortran_FLAGS_General       "-cpp ${MPI_Fortran_COMPILE_FLAGS}")
+
+  set(CMAKE_C_FLAGS_DEBUG         "-O2 -g")
+  set(CMAKE_C_FLAGS_RELEASE       "-O3")
+  set(C_FLAGS_General             "${MPI_C_COMPILE_FLAGS}")
+
+  find_package(OpenMP REQUIRED)
+  find_package(LAPACK REQUIRED)
+
+  set(OPENMP_FLAGS ${OpenMP_C_FLAGS})
+  set(LAPACK_FLAGS ${LAPACK_LINKER_FLAGS} ${LAPACK_LIBRARIES})
+endif ()
 
 set(TARGET_NAME         "ARTED_${BUILD_TARGET}${TARGET_SUFFIX}")
-set(CMAKE_Fortran_FLAGS "${ARCH} ${OPENMP_FLAGS} ${Fortran_FLAGS_General} ${ADDITIONAL_OPTIMIZE_FLAGS}")
-set(CMAKE_C_FLAGS       "${ARCH} ${OPENMP_FLAGS} ${C_FLAGS_General} ${ADDITIONAL_OPTIMIZE_FLAGS}")
+set(CMAKE_Fortran_FLAGS "${ARCH} ${OPENMP_FLAGS} ${Fortran_FLAGS_General} ${ADDITIONAL_OPTIMIZE_FLAGS} ${CMAKE_Fortran_FLAGS}")
+set(CMAKE_C_FLAGS       "${ARCH} ${OPENMP_FLAGS} ${C_FLAGS_General} ${ADDITIONAL_OPTIMIZE_FLAGS} ${CMAKE_C_FLAGS}")
 set(EXTERNAL_LIBS       "${LAPACK_FLAGS}")
 
 set(MODULE_LIB  modules)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Center for Computational Sciences, University of Tsukuba.
 
 ## Build Example
 
+    $ ./build
+    or
+    $ mkdir build_dir
+    $ cd build_dir
+    $ cmake .. && make
+
 ### for COMA at CCS, University of Tsukuba
     $ cd <ARTED Root Directory>
     $ module load intel intelmpi mkl

--- a/build
+++ b/build
@@ -26,6 +26,7 @@ from optparse import OptionParser
 import os
 import shutil
 
+MAKE_NUM_THREADS   = 8
 BUILD_TEMPDIR_NAME = '.build_temp'
 
 def on_or_off(v) :
@@ -40,7 +41,16 @@ def zero_or_one(v) :
   else:
     return '0'
 
-usage  = "usage: %prog [options] target-system target-architectures..."
+def build(build_dir, define_arch) :
+  if options.rebuild and os.path.exists(build_dir):
+    shutil.rmtree(build_dir)
+  if not os.path.exists(build_dir):
+    os.mkdir(build_dir)
+  if os.system('cd {0} && cmake {1} ../'.format(build_dir,define_arch)) == 0:
+    os.system('cd {0} && cmake ../ && make -j {1}'.format(build_dir,MAKE_NUM_THREADS))
+
+
+usage  = "usage: %prog [options] [target-system target-architectures...]"
 parser = OptionParser(usage)
 
 parser.add_option('-n', '--dry-run',       action='store_true',  default=False, dest='dry_run',           help='don\'t actually run.')
@@ -65,7 +75,7 @@ parser.add_option('--threads-profiler',    action='store_true',  default=False, 
 (options, args) = parser.parse_args()
 
 ### check args
-if len(args) < 2:
+if len(args) == 1:
   parser.print_help()
   exit(-1)
 
@@ -76,7 +86,10 @@ if options.target != 'sc' and options.target != 'ms':
   parser.print_help()
   exit(-1)
 
-target_system = args.pop(0)
+if len(args) >= 2:
+  target_system = args.pop(0)
+else:
+  target_system = ''
 
 dict = {}
 dict['BUILD_TARGET']           = options.target.lower()
@@ -96,18 +109,12 @@ define = ''
 for k,v in dict.items():
   define = '{0} -D {1}={2}'.format(define, k, v)
 
-for build_target_arch in args:
-  ### parallel build threads
-  build_num_threads=8
-
-  toolchain   = '{0}-{1}'.format(target_system,build_target_arch)
-  define_arch = '-D CMAKE_TOOLCHAIN_FILE={0} {1}'.format(toolchain,define)
-  build_dir   = '{0}_{1}_{2}_{3}'.format(BUILD_TEMPDIR_NAME,options.target,target_system,build_target_arch)
-
-  if options.rebuild and os.path.exists(build_dir):
-    shutil.rmtree(build_dir)
-  if not os.path.exists(build_dir):
-    os.mkdir(build_dir)
-
-  if os.system('cd {0} && cmake {1} ../'.format(build_dir,define_arch)) == 0:
-    os.system('cd {0} && cmake ../ && make -j {1}'.format(build_dir,build_num_threads))
+if not target_system:
+  build_dir = '{0}_{1}_native'.format(BUILD_TEMPDIR_NAME,options.target)
+  build(build_dir, define)
+else:
+  for build_target_arch in args:
+    toolchain   = '{0}-{1}'.format(target_system,build_target_arch)
+    define_arch = '-D CMAKE_TOOLCHAIN_FILE={0} {1}'.format(toolchain,define)
+    build_dir   = '{0}_{1}_{2}_{3}'.format(BUILD_TEMPDIR_NAME,options.target,target_system,build_target_arch)
+    build(build_dir, define_arch)


### PR DESCRIPTION
CMake can detects the below configurations,
- MPI Fortran/C compiler
- OpenMP flag 
- LAPACK(/BLAS) libraries

We can build the application easily.

```
$ ./build
or
$ mkdir build_dir
$ cd build_dir
$ cmake .. && make
```

If you want to set MPI compiler explicitly,
please set environment variable FC and CC.

```
$ FC=mpiifort CC=mpiicc ./build
or
$ FC=mpiifort CC=mpiicc cmake ..
```
