### PR TITLE
Fixed the performance degradation by the compiler optimization flag.

### DIFF
--- a/platform/fujitsu-fx100.cmake
+++ b/platform/fujitsu-fx100.cmake
@@ -9,10 +9,7 @@ set(ADDITIONAL_MACRO            "")
 set(ADDITIONAL_OPTIMIZE_FLAGS   "")
 
 set(Fortran_FLAGS_General       "-Cpp -Kocl,nooptmsg")
-set(C_FLAGS_General             "-Kocl,nooptmsg")
-
-set(Fortran_FLAGS_STENCIL       "")
-set(C_FLAGS_STENCIL             "-Xg -std=gnu99")
+set(C_FLAGS_General             "-Kocl,nooptmsg -Xg -std=gnu99")
 
 set(CMAKE_Fortran_COMPILER      "mpifrtpx")
 set(CMAKE_Fortran_FLAGS_DEBUG   "-O2 -g")

--- a/platform/fujitsu-k.cmake
+++ b/platform/fujitsu-k.cmake
@@ -11,9 +11,6 @@ set(ADDITIONAL_OPTIMIZE_FLAGS   "")
 set(Fortran_FLAGS_General       "-Cpp -Kocl,nooptmsg")
 set(C_FLAGS_General             "-Kocl,nooptmsg")
 
-set(Fortran_FLAGS_STENCIL       "")
-set(C_FLAGS_STENCIL             "")
-
 set(CMAKE_Fortran_COMPILER      "mpifrtpx")
 set(CMAKE_Fortran_FLAGS_DEBUG   "-O2 -g")
 set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -Kfast")

--- a/platform/gnu-generic.cmake
+++ b/platform/gnu-generic.cmake
@@ -16,15 +16,12 @@ set(ADDITIONAL_OPTIMIZE_FLAGS   "")
 set(Fortran_FLAGS_General       "-cpp")
 set(C_FLAGS_General             "-std=c99 -Wall")
 
-set(Fortran_FLAGS_STENCIL       "-fno-strict-aliasing")
-set(C_FLAGS_STENCIL             "-fno-strict-aliasing")
-
 set(CMAKE_Fortran_COMPILER      "mpif90")
 set(CMAKE_Fortran_FLAGS_DEBUG   "-O2 -g")
-set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+set(CMAKE_Fortran_FLAGS_RELEASE "-fno-strict-aliasing -O3")
 set(CMAKE_C_COMPILER            "mpicc")
 set(CMAKE_C_FLAGS_DEBUG         "-O2 -g")
-set(CMAKE_C_FLAGS_RELEASE       "-O3")
+set(CMAKE_C_FLAGS_RELEASE       "-fno-strict-aliasing -O3")
 
 
 ########

--- a/platform/intel-avx.cmake
+++ b/platform/intel-avx.cmake
@@ -9,17 +9,14 @@ set(ADDITIONAL_MACRO            "")
 set(ADDITIONAL_OPTIMIZE_FLAGS   "")
 
 set(Fortran_FLAGS_General       "-fpp -nogen-interface -std90 -warn all -diag-disable 6187,6477,6916,7025,7416")
-set(C_FLAGS_General             "-Wall")
-
-set(Fortran_FLAGS_STENCIL       "-ansi-alias -fno-alias")
-set(C_FLAGS_STENCIL             "-restrict -ansi-alias -fno-alias")
+set(C_FLAGS_General             "-Wall -restrict")
 
 set(CMAKE_Fortran_COMPILER      "mpiifort")
 set(CMAKE_Fortran_FLAGS_DEBUG   "-O2 -g")
-set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+set(CMAKE_Fortran_FLAGS_RELEASE "-ansi-alias -fno-alias -O3")
 set(CMAKE_C_COMPILER            "mpiicc")
 set(CMAKE_C_FLAGS_DEBUG         "-O2 -g")
-set(CMAKE_C_FLAGS_RELEASE       "-O3")
+set(CMAKE_C_FLAGS_RELEASE       "-ansi-alias -fno-alias -O3")
 
 set(ENABLE_STENCIL_WITH_C         1)
 set(ENABLE_EXPLICIT_VECTORIZATION 1)

--- a/platform/intel-avx2.cmake
+++ b/platform/intel-avx2.cmake
@@ -9,17 +9,14 @@ set(ADDITIONAL_MACRO            "")
 set(ADDITIONAL_OPTIMIZE_FLAGS   "")
 
 set(Fortran_FLAGS_General       "-fpp -nogen-interface -std90 -warn all -diag-disable 6187,6477,6916,7025,7416")
-set(C_FLAGS_General             "-Wall")
-
-set(Fortran_FLAGS_STENCIL       "-ansi-alias -fno-alias")
-set(C_FLAGS_STENCIL             "-restrict -ansi-alias -fno-alias")
+set(C_FLAGS_General             "-Wall -restrict")
 
 set(CMAKE_Fortran_COMPILER      "mpiifort")
 set(CMAKE_Fortran_FLAGS_DEBUG   "-O2 -g")
-set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+set(CMAKE_Fortran_FLAGS_RELEASE "-ansi-alias -fno-alias -O3")
 set(CMAKE_C_COMPILER            "mpiicc")
 set(CMAKE_C_FLAGS_DEBUG         "-O2 -g")
-set(CMAKE_C_FLAGS_RELEASE       "-O3")
+set(CMAKE_C_FLAGS_RELEASE       "-ansi-alias -fno-alias -O3")
 
 set(ENABLE_REDUCE_FOR_MANYCORE 1)
 

--- a/platform/intel-knc.cmake
+++ b/platform/intel-knc.cmake
@@ -9,17 +9,14 @@ set(ADDITIONAL_MACRO            "")
 set(ADDITIONAL_OPTIMIZE_FLAGS   "-qopt-streaming-stores always -qopt-gather-scatter-unroll=4 -qopt-ra-region-strategy=block")
 
 set(Fortran_FLAGS_General       "-fpp -nogen-interface -std90 -warn all -diag-disable 6187,6477,6916,7025,7416")
-set(C_FLAGS_General             "-Wall")
-
-set(Fortran_FLAGS_STENCIL       "-ansi-alias -fno-alias")
-set(C_FLAGS_STENCIL             "-restrict -ansi-alias -fno-alias")
+set(C_FLAGS_General             "-Wall -restrict")
 
 set(CMAKE_Fortran_COMPILER      "mpiifort")
 set(CMAKE_Fortran_FLAGS_DEBUG   "-qopt-assume-safe-padding -O2 -g")
-set(CMAKE_Fortran_FLAGS_RELEASE "-qopt-assume-safe-padding -O3")
+set(CMAKE_Fortran_FLAGS_RELEASE "-qopt-assume-safe-padding -ansi-alias -fno-alias -O3")
 set(CMAKE_C_COMPILER            "mpiicc")
 set(CMAKE_C_FLAGS_DEBUG         "-qopt-assume-safe-padding -O2 -g")
-set(CMAKE_C_FLAGS_RELEASE       "-qopt-assume-safe-padding -O3")
+set(CMAKE_C_FLAGS_RELEASE       "-qopt-assume-safe-padding -ansi-alias -fno-alias -O3")
 
 set(ENABLE_STENCIL_WITH_C         1)
 set(ENABLE_EXPLICIT_VECTORIZATION 1)

--- a/stencil/CMakeLists.txt
+++ b/stencil/CMakeLists.txt
@@ -1,8 +1,6 @@
 ###
 ### Compile stencil computation sources
 ###
-set(CMAKE_Fortran_FLAGS "${ARCH} ${OPENMP_FLAGS} ${Fortran_FLAGS_General} ${Fortran_FLAGS_STENCIL}")
-set(CMAKE_C_FLAGS       "${ARCH} ${OPENMP_FLAGS} ${C_FLAGS_General} ${C_FLAGS_STENCIL}")
 
 ### Soruces for current and total_energy
 set(SOURCES_COMPILER_VEC


### PR DESCRIPTION
Removed two variables in CMake.
1. Fortran_FLAGS_STENCIL
2. C_FLAGS_STENCIL
