### PR TITLE
Add minimal stencil performance checker.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,9 @@ set(FDTD_LIB    FDTD)
 set(CMAKE_Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR})
 set(EXECUTABLE_OUTPUT_PATH "${PROJECT_SOURCE_DIR}/${BINARY_DIR}")
 
+if("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
+  set(FIX_Fortran_NOMAIN "-nofor-main")
+endif ()
 
 ### Set optimize options
 option(USE_TLOG            "Use TLOG library"               OFF)
@@ -187,6 +190,7 @@ add_subdirectory(GS)
 add_subdirectory(RT)
 add_subdirectory(common)
 add_subdirectory(stencil)
+add_subdirectory(perfcheck)
 add_executable(${TARGET_NAME} main/${BUILD_TARGET}.f90)
 
 add_dependencies(${TARGET_NAME} ${MODULE_LIB} ${STENCIL_LIB})

--- a/modules/performance_analyzer.f90
+++ b/modules/performance_analyzer.f90
@@ -17,6 +17,7 @@ module performance_analyzer
   implicit none
 
   public  print_stencil_size, show_performance
+  public  get_hamiltonian_performance
 
   private summation_threads, get_gflops, get_hamiltonian_chunk_size
   private get_stencil_FLOP, get_pseudo_pt_FLOP, get_update_FLOP
@@ -34,6 +35,12 @@ contains
     print *, 'NL =', NL
     print *, 'Nt =', (Nt + 1)
     print *, 'Number of Domain/Thread =', real(NK * NB) / NUMBER_THREADS
+  end subroutine
+
+  subroutine get_hamiltonian_performance(lgflops)
+    implicit none
+    real(8) :: lgflops(4)
+    call summation_threads(lgflops)
   end subroutine
 
   subroutine show_performance

--- a/perfcheck/CMakeLists.txt
+++ b/perfcheck/CMakeLists.txt
@@ -1,0 +1,13 @@
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${FIX_Fortran_NOMAIN}")
+set(TARGET stencilperf${TARGET_SUFFIX})
+set(SOURCES
+    wrap_variables.f90
+    stencil_perf_check.f90
+    main.c
+    )
+
+add_executable(${TARGET} EXCLUDE_FROM_ALL ${SOURCES})
+add_dependencies(${TARGET} ${MODULE_LIB} ${COMMON_LIB} ${RT_LIB} ${STENCIL_LIB})
+target_link_libraries(${TARGET} ${MODULE_LIB} ${COMMON_LIB} ${RT_LIB} ${STENCIL_LIB})
+
+add_custom_target(stencilperf DEPENDS ${TARGET})

--- a/perfcheck/main.c
+++ b/perfcheck/main.c
@@ -1,0 +1,120 @@
+/*
+ *  Copyright 2016 ARTED developers
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#include <stdio.h>
+#include <getopt.h>
+#define IS_RANGE(X, V, Y) ((X <= V) && (V <= Y))
+
+static const int NLx = 16;
+static const int NLy = 16;
+static const int NLz = 16;
+static const int NK  = 8*8*8;
+static const int NB  = 16;
+static const int Nt  = 10;
+
+void usage(char const* name)
+{
+  fprintf(stderr,
+          "ARTED 25-points stencil computation performance checker\n\n"
+          "[Usage]\n"
+          "%s [-h] [-p] [-l NXxNYxNZ] [-k NK] [-b NB] [-s Nt]\n"
+          "  -l : set lattice size (default = %dx%dx%d)\n"
+          "  -k : set k-point size (default = %d)\n"
+          "  -b : set band size    (default %d)\n"
+          "  -s : set step size    (default %d)\n"
+          "  -h : show this help message\n"
+          "  -p : show preprocessor definitions\n",
+          name,
+          NLx, NLy, NLz,
+          NK,
+          NB,
+          Nt
+  );
+}
+
+int main(int argc, char* argv[])
+{
+  int result;
+
+  int nlx = NLx, nly = NLy, nlz = NLz;
+  int nk = NK, nb = NB, nt = Nt;
+
+  while((result = getopt(argc, argv, "l:k:b:s:hp")) != -1)
+  {
+    switch(result)
+    {
+      case 'l':
+        {
+          int x_, y_, z_;
+          sscanf(optarg, "%dx%dx%d", &x_, &y_, &z_);
+          if(!(IS_RANGE(4, x_, 512) && IS_RANGE(4, y_, 512) && IS_RANGE(4, z_, 512))) {
+            fprintf(stderr, "lattice size is out of range. (4 <= NLx,y,z <= 512)\n");
+            exit(-1);
+          }
+          nlx = x_;
+          nly = y_;
+          nlz = z_;
+        }
+        break;
+      case 'k':
+        {
+          int k_;
+          sscanf(optarg, "%d", &k_);
+          if(!IS_RANGE(1, k_, (int)pow(2,24))) {
+            fprintf(stderr, "k-point size is out of range. (1 <= NK <= 2^24)\n");
+            exit(-1);
+          }
+          nk = k_;
+        }
+        break;
+      case 'b':
+        {
+          int b_;
+          sscanf(optarg, "%d", &b_);
+          if(!IS_RANGE(1, b_, (int)pow(2,24))) {
+            fprintf(stderr, "k-point size is out of range. (1 <= NK <= 2^24)\n");
+            exit(-1);
+          }
+          nb = b_;
+        }
+        break;
+      case 's':
+        {
+          int t_;
+          sscanf(optarg, "%d", &t_);
+          if(t_ < 1) {
+            fprintf(stderr, "Nt is invalid value (Nt < 1).\n");
+            exit(-1);
+          }
+          nt = t_;
+        }
+        break;
+      case 'h':
+        usage(argv[0]);
+        exit(0);
+      case 'p':
+        print_optimize_message_();
+        exit(0);
+      case '?':
+      default:
+        usage(argv[0]);
+        exit(-1);
+    }
+  }
+
+  stencil_perf_check_(&nlx, &nly, &nlz, &nk, &nb, &nt);
+
+  return 0;
+}

--- a/perfcheck/stencil_perf_check.f90
+++ b/perfcheck/stencil_perf_check.f90
@@ -1,0 +1,77 @@
+!
+!  Copyright 2016 ARTED developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+subroutine stencil_perf_check(NLx_, NLy_, NLz_, NK_, NB_, Nt_)
+  use global_variables, only: NLx,NLy,NLz,NK,NBoccmax,NUMBER_THREADS,Nt
+  use wrap_variables
+  use performance_analyzer
+  use timelog
+  use omp_lib
+  implicit none
+  integer,intent(in) :: NLx_, NLy_, NLz_
+  integer,intent(in) :: NK_, NB_, Nt_
+
+  integer :: t
+  real(8) :: tbeg,tend
+  real(8) :: time(4), gflops(4)
+
+  NUMBER_THREADS = omp_get_max_threads()
+
+  NLx      = NLx_
+  NLy      = NLy_
+  NLz      = NLz_
+  NK       = NK_
+  NBoccmax = NB_
+  Nt       = Nt_
+
+  print '("THREADS  =",i6)', NUMBER_THREADS
+  print '("NK       =",i6)', NK
+  print '("NBoccmax =",i6)', NBoccmax
+  print '("NLx,y,z  =",i6,i6,i6)', NLx,NLy,NLz
+  print '("step     =",i6)', Nt
+  print *, ''
+  Nt = Nt - 1
+
+  call wrap_init
+  call timelog_initialize
+
+  call dt_evolve_hpsi
+
+  call timelog_reset
+  tbeg = omp_get_wtime()
+  do t=0,Nt
+    call dt_evolve_hpsi
+  end do
+  tend = omp_get_wtime()
+
+  time(1) = timelog_get(LOG_HPSI_STENCIL)
+  time(2) = timelog_get(LOG_HPSI_UPDATE)
+  call get_hamiltonian_performance(gflops)
+
+  print '("total   time =",f6.2," sec")', tend - tbeg
+  print '("stencil time =",f6.2," sec,",f8.2," GFLOPS")', time(1), gflops(1)
+  print '("update  time =",f6.2," sec,",f8.2," GFLOPS")', time(2), gflops(3)
+end subroutine
+
+subroutine err_finalize(err_message)
+  use Global_Variables
+  implicit none
+  character(*),intent(in) :: err_message
+  if (Myrank == 0) then
+    write(*,*) err_message
+  endif
+  call MPI_FINALIZE(ierr)
+  stop
+end subroutine err_finalize

--- a/perfcheck/wrap_variables.f90
+++ b/perfcheck/wrap_variables.f90
@@ -1,0 +1,139 @@
+!
+!  Copyright 2016 ARTED developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+module wrap_variables
+  implicit none
+
+  public wrap_init
+
+#ifdef ARTED_STENCIL_ORIGIN
+  private init_original
+#endif
+
+contains
+  subroutine wrap_init
+    use global_variables
+    use opt_variables
+    implicit none
+    integer :: ix,iy,iz,i,ik,ib
+
+    ! wrap global_variables
+    Nd = 4
+    NL  = NLx*NLy*NLz
+    NK_s = 1
+    NK_e = NK
+    dt = 0.02d0
+    functional = 'PZ'
+    NKB = (NK_e - NK_s + 1) * NBoccmax
+    Nlma = 0
+
+    allocate(zu(NL,NBoccmax,NK_s:NK_e))
+    allocate(kAc(NK,3))
+    allocate(Vloc(NL))
+    allocate(lapx(-Nd:Nd),lapy(-Nd:Nd),lapz(-Nd:Nd))
+    allocate(nabx(-Nd:Nd),naby(-Nd:Nd),nabz(-Nd:Nd))
+    allocate(ik_table(NKB),ib_table(NKB))
+
+    kAc(:,:) = 0.5d0
+    Vloc(:) = 0.33333d0
+
+    lapx(:) = 1.0d0
+    lapy(:) = 1.0d0
+    lapz(:) = 1.0d0
+    lapt(:) = 1.0d0
+
+    nabx(:) = 0.25d0
+    naby(:) = 0.25d0
+    nabz(:) = 0.25d0
+
+    i=0
+    do ik=NK_s,NK_e
+      do ib=1,NBoccmax
+        i=i+1
+        ik_table(i)=ik
+        ib_table(i)=ib
+      end do
+    end do
+
+#ifdef ARTED_STENCIL_ORIGIN
+    call init_original
+#endif
+
+    ! wrap opt_variables
+    PNLx = NLx
+#ifdef ARTED_STENCIL_PADDING
+    PNLy = NLy + 1
+#else
+    PNLy = NLy
+#endif
+    PNLz = NLz
+    PNL = PNLx*PNLy*PNLz
+
+    allocate(ztpsi(0:PNL-1,4,0:NUMBER_THREADS-1))
+    allocate(zcx(NBoccmax,NK_s:NK_e))
+    allocate(zcy(NBoccmax,NK_s:NK_e))
+    allocate(zcz(NBoccmax,NK_s:NK_e))
+    allocate(modx(0:NLx*2+Nd-1))
+    allocate(mody(0:NLy*2+Nd-1))
+    allocate(modz(0:NLz*2+Nd-1))
+
+    do ix=0,NLx*2+Nd-1
+      modx(ix) = mod(ix,NLx)
+    end do
+    do iy=0,NLy*2+Nd-1
+      mody(iy) = mod(iy,NLy)
+    end do
+    do iz=0,NLz*2+Nd-1
+      modz(iz) = mod(iz,NLz)
+    end do
+
+#ifdef ARTED_STENCIL_LOOP_BLOCKING
+    call auto_blocking
+#endif
+  end subroutine
+
+#ifdef ARTED_STENCIL_ORIGIN
+  subroutine init_original
+    use global_variables
+    use opt_variables
+    implicit none
+    integer :: ix,iy,iz,i,j
+
+    allocate(zifdx(-4:4,0:NL-1))
+    allocate(zifdy(-4:4,0:NL-1))
+    allocate(zifdz(-4:4,0:NL-1))
+
+    do ix=0,NLx-1
+    do iy=0,NLy-1
+    do iz=0,NLz-1
+      i = ix*NLy*NLz + iy*NLz + iz
+      do j=1,4
+        zifdx( j, i) = mod(ix+j+NLx,NLx)*NLy*NLz + iy*NLz + iz
+        zifdx(-j, i) = mod(ix-j+NLx,NLx)*NLy*NLz + iy*NLz + iz
+      end do
+      do j=1,4
+        zifdy( j, i) = ix*NLy*NLz + mod(iy+j+NLy,NLy)*NLz + iz
+        zifdy(-j, i) = ix*NLy*NLz + mod(iy-j+NLy,NLy)*NLz + iz
+      end do
+      do j=1,4
+        zifdz( j, i) = ix*NLy*NLz + iy*NLz + mod(iz+j+NLz,NLz)
+        zifdz(-j, i) = ix*NLy*NLz + iy*NLz + mod(iz-j+NLz,NLz)
+      end do
+    end do
+    end do
+    end do
+  end subroutine
+#endif
+end module


### PR DESCRIPTION
./build script does not support the make target.
Please use CMake directly.

``` bash
$ cmake .....
$ make stencilperf
$ ls ${ARTED_ROOT}/bin
stencilperf.cpu
```
