### PR TITLE
Non-uniform k-point distribution

### DIFF
--- a/GS/Fermi_Dirac_distribution.f90
+++ b/GS/Fermi_Dirac_distribution.f90
@@ -41,7 +41,7 @@ Subroutine Fermi_Dirac_distribution
 
     do ik=NK_s,NK_e
       do ib=1,NB
-        occ_l(ib,ik)=2.d0/(NKx*NKy*NKz)*wk(ik) &
+        occ_l(ib,ik)=2.d0/(NKxyz)*wk(ik) &
           &/(exp(beta_FD*(esp(ib,ik)-chemical_potential))+1d0)
       end do
     end do

--- a/main/sc.f90
+++ b/main/sc.f90
@@ -616,7 +616,6 @@ Subroutine Read_data
   call MPI_BCAST(file_dns,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
   call MPI_BCAST(file_ovlp,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
   call MPI_BCAST(file_nex,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(file_kw,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr) !uemoto
   call MPI_BCAST(aL,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
   call MPI_BCAST(ax,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
   call MPI_BCAST(ay,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)

--- a/main/sc.f90
+++ b/main/sc.f90
@@ -557,6 +557,10 @@ Subroutine Read_data
     read(*,*) aL,ax,ay,az
     read(*,*) Sym,crystal_structure ! sym
     read(*,*) Nd,NLx,NLy,NLz,NKx,NKy,NKz
+    !uemoto
+    if ((NKx <= 0) .or. (NKy <= 0) .or. (NKz <= 0)) then
+      read(*,*) file_kw
+    endif
     read(*,*) NEwald, aEwald
     read(*,*) KbTev ! sato
 
@@ -612,6 +616,7 @@ Subroutine Read_data
   call MPI_BCAST(file_dns,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
   call MPI_BCAST(file_ovlp,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
   call MPI_BCAST(file_nex,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
+  call MPI_BCAST(file_kw,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr) !uemoto
   call MPI_BCAST(aL,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
   call MPI_BCAST(ax,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
   call MPI_BCAST(ay,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
@@ -672,16 +677,32 @@ Subroutine Read_data
   Hxyz=Hx*Hy*Hz
   NL=NLx*NLy*NLz
   NG=NL
-  NKxyz=NKx*NKy*NKz
 
-  select case(Sym)
-  case(1)
-    NK=NKx*NKy*NKz
-  case(4)
-    NK=(NKx/2)*(NKy/2)*NKz
-  case(8)
-    NK=NKz*(NKx/2)*((NKx/2)+1)/2
-  end select
+  ! Added by M.Uemoto on 2016-07-07
+  if (0<NKx .and. 0<NKy .and. 0<NKy) then
+    ! Use uniform rectangular k-grid
+    NKxyz=NKx*NKy*NKz
+    select case(Sym)
+    case(1)
+      NK=NKx*NKy*NKz
+    case(4)
+      NK=(NKx/2)*(NKy/2)*NKz
+    case(8)
+      NK=NKz*(NKx/2)*((NKx/2)+1)/2
+    end select
+  else
+    ! Use non-uniform k-points
+    if (myrank == 0) then
+      write(*,*) "Use non-uniform k-points distribution"
+      write(*,*) "file_kw=", file_kw
+      open(410, file=file_kw, status="old")
+      read(410, *) NK, NKxyz
+      close(410)
+      write(*,*) "NK=", NK, "NKxyz=", NKxyz      
+    endif
+    call MPI_BCAST(NK,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
+    call MPI_BCAST(NKxyz,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
+  endif
 
   NK_ave=NK/Nprocs; NK_remainder=NK-NK_ave*Nprocs
   NG_ave=NG/Nprocs; NG_remainder=NG-NG_ave*Nprocs

--- a/modules/global_variables_sc.f90
+++ b/modules/global_variables_sc.f90
@@ -124,6 +124,7 @@ Module Global_Variables
   character(50) :: file_force_dR,file_j_ac
   character(50) :: file_DoS,file_band
   character(50) :: file_dns,file_ovlp,file_nex
+  character(50) :: file_kw ! non-uniform k-grid 
   character(2) :: ext_field
   character(2) :: Longi_Trans
   character(1) :: FSset_option,MD_option

--- a/preparation/init.f90
+++ b/preparation/init.f90
@@ -84,7 +84,7 @@ Subroutine init
   if (0 < NKx .and. 0<NKy .and. 0<NKz) then
     call init_uniform_k_grid()
   else
-    call init_non_uniform_k_grid() ! Load k-points from SYSNAME_k.dat
+    call init_non_uniform_k_grid()
   endif
 
   do ib=1,NB
@@ -305,7 +305,7 @@ subroutine init_non_uniform_k_grid()
   real(8) :: temp(4)
 
   if (myrank == 0) then
-    ! Read coordinates from "SYSNAME_k.dat"
+    ! Read coordinates from file_kw
     open(410, file=file_kw, status="old")
     read(410, *) nk_dummy, nkxyz_dummy
     do i=1, NK

--- a/preparation/init.f90
+++ b/preparation/init.f90
@@ -81,56 +81,14 @@ Subroutine init
     end do
   end do
 
-  Select case(Sym)
-  case(1)
-    n=0
-    do ix=1,NKx
-    do iy=1,NKy
-    do iz=1,NKz
-      n=n+1
-      kAc(n,1)=-bLx/2+(ix-0.5d0)*bLx/NKx
-      kAc(n,2)=-bLy/2+(iy-0.5d0)*bLy/NKy
-      kAc(n,3)=-bLz/2+(iz-0.5d0)*bLz/NKz
-      wk(n)=1.d0
-    enddo
-    enddo
-    enddo
-  case(4)
-    n=0
-    do ix=1,NKx/2
-    do iy=1,NKy/2
-    do iz=1,NKz
-      n=n+1
-      kAc(n,1)=-bLx/2+(ix-0.5d0)*bLx/NKx
-      kAc(n,2)=-bLy/2+(iy-0.5d0)*bLy/NKy
-      kAc(n,3)=-bLz/2+(iz-0.5d0)*bLz/NKz
-      wk(n)=4.d0
-    enddo
-    enddo
-    enddo
-  case(8)
-! assume NKx == NKy
-    n=0
-    do ix=1,NKx/2
-    do iy=1,ix
-    do iz=1,NKz
-      n=n+1
-      kAc(n,1)=-bLx/2+(ix-0.5d0)*bLx/NKx
-      kAc(n,2)=-bLy/2+(iy-0.5d0)*bLy/NKy
-      kAc(n,3)=-bLz/2+(iz-0.5d0)*bLz/NKz
-      wk(n)=8.d0
-      if(ix == iy) wk(n)=4.d0
-    enddo
-    enddo
-    enddo
-  end select
-
-! yabana
-  kAc0=kAc
-! yabana
+  if (0 < NKx .and. 0<NKy .and. 0<NKz) then
+    call init_uniform_k_grid()
+  else
+    call init_non_uniform_k_grid() ! Load k-points from SYSNAME_k.dat
+  endif
 
   do ib=1,NB
-    occ(ib,1:NK)=2.d0/(NKx*NKy*NKz)*wk(1:NK)
+    occ(ib,1:NK)=2.d0/(NKxyz)*wk(1:NK)
   enddo
   if (NBoccmax < NB) occ(NBoccmax+1:NB,:)=0.d0
   Ne_tot=sum(occ)
@@ -285,4 +243,88 @@ Subroutine init
 
   return
 End Subroutine Init
+
+
+subroutine init_uniform_k_grid()
+  use Global_Variables
+  implicit none
+  integer :: n,ix,iy,iz
+  Select case(Sym)
+  case(1)
+    n=0
+    do ix=1,NKx
+    do iy=1,NKy
+    do iz=1,NKz
+      n=n+1
+      kAc(n,1)=-bLx/2+(ix-0.5d0)*bLx/NKx
+      kAc(n,2)=-bLy/2+(iy-0.5d0)*bLy/NKy
+      kAc(n,3)=-bLz/2+(iz-0.5d0)*bLz/NKz
+      wk(n)=1.d0
+    enddo
+    enddo
+    enddo
+  case(4)
+    n=0
+    do ix=1,NKx/2
+    do iy=1,NKy/2
+    do iz=1,NKz
+      n=n+1
+      kAc(n,1)=-bLx/2+(ix-0.5d0)*bLx/NKx
+      kAc(n,2)=-bLy/2+(iy-0.5d0)*bLy/NKy
+      kAc(n,3)=-bLz/2+(iz-0.5d0)*bLz/NKz
+      wk(n)=4.d0
+    enddo
+    enddo
+    enddo
+  case(8)
+! assume NKx == NKy
+    n=0
+    do ix=1,NKx/2
+    do iy=1,ix
+    do iz=1,NKz
+      n=n+1
+      kAc(n,1)=-bLx/2+(ix-0.5d0)*bLx/NKx
+      kAc(n,2)=-bLy/2+(iy-0.5d0)*bLy/NKy
+      kAc(n,3)=-bLz/2+(iz-0.5d0)*bLz/NKz
+      wk(n)=8.d0
+      if(ix == iy) wk(n)=4.d0
+    enddo
+    enddo
+    enddo
+  end select
+  kAc0=kAc  ! Store initial k-point coordinates
+end subroutine
+
+
+
+subroutine init_non_uniform_k_grid()
+  use Global_Variables
+  implicit none
+  integer :: i,j,ik
+  integer :: nk_dummy, nkxyz_dummy
+  real(8) :: temp(4)
+
+  if (myrank == 0) then
+    ! Read coordinates from "SYSNAME_k.dat"
+    open(410, file=file_kw, status="old")
+    read(410, *) nk_dummy, nkxyz_dummy
+    do i=1, NK
+      read(410, *) ik, (temp(j), j=1, 4)
+      kAc(ik, 1) = temp(1) * bLx
+      kAc(ik, 2) = temp(2) * bLy
+      kAc(ik, 3) = temp(3) * bLz
+      wk(ik) = temp(4)
+    enddo
+    close(410)
+  endif
+  call MPI_BCAST(kAc,3*NK,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
+  call MPI_BCAST(wk,NK,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
+  if (abs(sum(wk) - NKxyz) > NKxyz*0.01) then
+    call err_finalize('NKxyz must be an integer which equals to the summention of WK')
+  endif
+  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  kAc0=kAc  ! Store initial k-point coordinates
+end subroutine
+
+
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130


### PR DESCRIPTION
This patch provides the calculation mode to use the non-uniform k-point distribution.
In this modified version, if 'NQ' of input file is set to be zero or negative number, the program loads the set of k-coordinates from external file and use them for calculation, instead of the rectangular k-grid. 
