### PR TITLE
Update a OpenACC code.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,8 +154,9 @@ endif ()
 
 ### NVIDIA Tools Extension Library
 if (USE_NVTX)
+  find_package(CUDA REQUIRED)
   add_definitions(-DARTED_USE_NVTX)
-  link_directories(/usr/local/cuda/lib64)
+  link_directories(${CUDA_TOOLKIT_ROOT_DIR}/lib64)
   set(EXTERNAL_LIBS ${EXTERNAL_LIBS} nvToolsExt)
 endif ()
 

--- a/RT/current.f90
+++ b/RT/current.f90
@@ -230,7 +230,9 @@ subroutine current_omp_KB_ST(ib,ik,A)
   zcy(ib,ik)=zy
   zcz(ib,ik)=zz
 end subroutine
-
+#endif
+!--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
+#ifdef ARTED_CURRENT_OPTIMIZED
 #ifdef ARTED_LBLK
 subroutine current_acc_KB_ST_LBLK(A, ikb_s,ikb_e)
   use Global_Variables
@@ -239,32 +241,10 @@ subroutine current_acc_KB_ST_LBLK(A, ikb_s,ikb_e)
   complex(8),intent(in) :: A(0:NL-1, NBoccmax, NK_s:NK_e)
   integer,intent(in)    :: ikb_s,ikb_e
 
-  real(8) :: nabt(12),zx,zy,zz
-  integer :: ikb,ik,ib
-
-#if 1
   call current_stencil_LBLK(A(:,:,:), ikb_s,ikb_e)
-#else
-  nabt( 1: 4) = nabx(1:4)
-  nabt( 5: 8) = naby(1:4)
-  nabt( 9:12) = nabz(1:4)
-  do ikb=ikb_s,ikb_e
-    ik=ik_table(ikb)
-    ib=ib_table(ikb)
-
-    zx = 0.d0
-    zy = 0.d0
-    zz = 0.d0
-    call current_stencil(nabt,A(:,ib,ik),zx,zy,zz)
-    zcx(ib,ik)=zx
-    zcy(ib,ik)=zy
-    zcz(ib,ik)=zz
-  enddo
-#endif
-
 end subroutine
-#endif ! ARTED_LBLK
-#endif ! ARTED_CURRENT_OPTIMIZED
+#endif
+#endif
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 Subroutine current_GS_omp_KB
   use Global_Variables
@@ -385,8 +365,10 @@ Subroutine current_RT_stencil_impl(ik,ib,jx,jy,jz)
   jy=jy+zcy(ib,ik)*occ(ib,ik)
   jz=jz+zcz(ib,ik)*occ(ib,ik)
 end Subroutine
+#endif
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 #ifdef ARTED_LBLK
+!--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 Subroutine current_RT_stencil_impl_LBLK(jx,jy,jz, ikb_s,ikb_e)
   use Global_Variables
   use opt_variables
@@ -408,7 +390,7 @@ Subroutine current_RT_stencil_impl_LBLK(jx,jy,jz, ikb_s,ikb_e)
 !$acc end kernels
 !$acc end data
 end Subroutine
-#endif ! ARTED_LBLK
+!--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 #endif
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 Subroutine current_pseudo_impl(ik,ib,zutmp,IaLxyz,jx,jy,jz)
@@ -643,7 +625,7 @@ Subroutine current_omp_KB_impl(zutmp,jxs,jys,jzs)
 !$omp end parallel
 end Subroutine
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
-#ifdef _OPENACC
+#ifdef ARTED_LBLK
 subroutine current_acc_KB_impl(zutmp,jxs,jys,jzs)
   use Global_Variables
   use opt_variables
@@ -687,12 +669,10 @@ subroutine current_acc_KB_impl(zutmp,jxs,jys,jzs)
     ikb_e = ikb0 + num_ikb1-1
 
     call current_init_impl_LBLK(zutmp(:,:,:), jx(:),jy(:),jz(:), ikb_s,ikb_e)
-
 #ifndef ARTED_CURRENT_OPTIMIZED
     call current_stencil_LBLK(zutmp(:,:,:), ikb_s,ikb_e)
 #endif
     call current_RT_stencil_impl_LBLK(jx(:),jy(:),jz(:), ikb_s,ikb_e)
-
     call current_pseudo_impl_LBLK(zutmp(:,:,:),IaLxyz,jx(:),jy(:),jz(:), ikb_s,ikb_e)
   enddo
 

--- a/common/Hartree.f90
+++ b/common/Hartree.f90
@@ -17,20 +17,9 @@
 !This file contain one subroutine.
 !SUBROUTINE Hartree
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
-#ifdef ARTED_USE_NVTX
-#define NVTX_BEG(name,id)  call nvtxStartRange(name,id)
-#define NVTX_END()         call nvtxEndRange()
-#else
-#define NVTX_BEG(name,id)
-#define NVTX_END()
-#endif
-
 Subroutine Hartree
   use Global_Variables
   use timelog
-#ifdef ARTED_USE_NVTX
-  use nvtx
-#endif
   implicit none
   integer :: i,ix,iy,iz,n,nx,ny,nz
   real(8) :: G2

--- a/common/psi_rho.f90
+++ b/common/psi_rho.f90
@@ -185,16 +185,15 @@ contains
 
     NVTX_BEG("sym1()",1)
 
-#ifndef _OPENACC
+#ifdef _OPENACC
+    call reduce_acc(1.0d0,zutmp,zu_NB,zrho_l)
+#else
 !$omp parallel private(tid)
 !$  tid=omp_get_thread_num()
     call reduce(tid,1.0d0,zutmp,zu_NB)
 !$omp end parallel
 
     zrho_l(:) = zrhotmp(0:NL-1,0)
-#else
-    !
-    call reduce_acc(1.0d0, zutmp, zu_NB, zrho_l)
 #endif
 
     NVTX_END()
@@ -218,9 +217,16 @@ contains
 
     zfac=1.0d0/4d0
 
+#ifdef _OPENACC
+    call reduce_acc(zfac,zutmp,zu_NB,zrhotmp(:,0))
+#endif
+
 !$omp parallel private(tid)
 !$  tid=omp_get_thread_num()
+
+#ifndef _OPENACC
     call reduce(tid,zfac,zutmp,zu_NB)
+#endif
 
 ! 1.T_3
 !$omp do OMP_SIMD
@@ -260,9 +266,16 @@ contains
     ! wk(ik)=8.0,(ikx==iky >. wk(ik)=4.0)
     zfac=1.0d0/32d0
 
+#ifdef _OPENACC
+    call reduce_acc(zfac,zutmp,zu_NB,zrhotmp(:,0))
+#endif
+
 !$omp parallel private(tid)
 !$  tid=omp_get_thread_num()
+
+#ifndef _OPENACC
     call reduce(tid,zfac,zutmp,zu_NB)
+#endif
 
 ! 1.T_4
 !$omp do OMP_SIMD
@@ -300,6 +313,7 @@ contains
 !$omp end do OMP_SIMD
 !$omp end parallel
   end subroutine
+
   !====== tetragonal(8) structure =========================!
   subroutine sym8_tetragonal(zutmp,zu_NB,zrho_l,zrhotmp1,zrhotmp2)
     use global_variables
@@ -318,9 +332,16 @@ contains
     ! wk(ik)=8.0,(ikx==iky >. wk(ik)=4.0)
     zfac=1.0d0/16d0
 
+#ifdef _OPENACC
+    call reduce_acc(zfac,zutmp,zu_NB,zrhotmp(:,0))
+#endif
+
 !$omp parallel private(tid)
 !$  tid=omp_get_thread_num()
+
+#ifndef _OPENACC
     call reduce(tid,zfac,zutmp,zu_NB)
+#endif
 
 ! 1.T_3
 !$omp do OMP_SIMD

--- a/stencil/F90/current.f90
+++ b/stencil/F90/current.f90
@@ -116,7 +116,8 @@ end subroutine
 
 #ifdef ARTED_LBLK
 subroutine current_stencil_LBLK(E, ikb_s,ikb_e)
-  use global_variables
+  use global_variables, only: ik_table,ib_table,NBoccmax,NK_s,NK_e,NLx,NLy,NLz, &
+  &                           nabx,naby,nabz,zI
   use opt_variables
   implicit none
   complex(8), intent(in)  :: E(0:NLz-1,0:NLy-1,0:NLx-1, NBoccmax, NK_s:NK_e)


### PR DESCRIPTION
1. A multi-scale simulation mode can be executed with OpenACC
2. psi_rho() supports OpenACC with all mode (sym1(), sym4(), sym8(), sym8_tetragonal())
3. Fixed a current() compile error with a few case
4. CMake uses FindCUDA package
