### PR TITLE
Fixed a unspecified license.

### DIFF
--- a/modules/nvtx.f90
+++ b/modules/nvtx.f90
@@ -1,4 +1,19 @@
 !
+!  Copyright 2016 ARTED developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+! ===
 ! wrapper for NVTX
 ! see https://devblogs.nvidia.com/parallelforall/customize-cuda-fortran-profiling-nvtx/
 !


### PR DESCRIPTION
modules/nvtx.f90 is not specified the license.
This file was created by Mr. Akira Naruse (NVIDIA).
We obtained the consent of this patch from the original author.