### PR TITLE
Fix a bug in the pseudopotential preparation.

### DIFF
--- a/preparation/input_ps.f90
+++ b/preparation/input_ps.f90
@@ -167,14 +167,11 @@ Subroutine input_pseudopotential_YS
         end do
         anorm(l,ik) = 0.5d0*anorm(l,ik)
         inorm(l,ik)=+1
-        if(abs(anorm(l,ik)).lt.Eps0) then
-          inorm(l,ik)=0
-        else 
-          if(anorm(l,ik).lt.0.d0) then
-            anorm(l,ik)=-anorm(l,ik)
-            inorm(l,ik)=-1
-          endif
+        if(anorm(l,ik).lt.0.d0) then
+          anorm(l,ik)=-anorm(l,ik)
+          inorm(l,ik)=-1
         endif
+        if(abs(anorm(l,ik)).lt.Eps0)inorm(l,ik)=0
         anorm(l,ik)=sqrt(anorm(l,ik))
       enddo
 


### PR DESCRIPTION
Fixed a bug in the pseudopotential preparation. In the old implementation, if "abs(anorm(l,ik)).lt.Eps0" and "anorm(l,ik).lt.0.d0", "sqrt(anorm(l,ik))" gives "NaN".
However, in that case, "inorm" becomes zero, and thus "anorm" does not affect the calculation. So, this bug changes nothing indeed.