### PR TITLE
Bugfix  for # of excited electron in MS calc.

### DIFF
--- a/main/ms.f90
+++ b/main/ms.f90
@@ -397,7 +397,7 @@ Program main
 
       call timelog_begin(LOG_K_SHIFT_WF)
 !Adiabatic evolution
-      if (AD_RHO /= 'No' .and. iter/100*100 == iter) then
+      if (AD_RHO /= 'No' .and. mod(iter,100) == 0) then
         call k_shift_wf(Rion_update,2)
         if(NEWRANK == 0)then ! sato
           excited_electron_l(ix_m,iy_m)=sum(occ)-sum(ovlp_occ(1:NBoccmax,:))
@@ -487,7 +487,7 @@ Program main
     
     end if
 
-    if (AD_RHO /= 'No' .and. iter/100*100 == 0 ) then 
+    if (AD_RHO /= 'No' .and. mod(iter,100) == 0 ) then 
       call timelog_begin(LOG_ALLREDUCE)
       call MPI_ALLREDUCE(excited_electron_l,excited_electron &
         &,NX_m*NY_m,MPI_REAL8,MPI_SUM,MPI_COMM_WORLD,ierr)


### PR DESCRIPTION
I fixed a bug for writing the number of excited electrons in the multi-scale calculation; timings of the calculation and the output were not consistent.