### PR TITLE
Implemented nonlinear core correction

### DIFF
--- a/common/Exc_Cor.f90
+++ b/common/Exc_Cor.f90
@@ -942,7 +942,7 @@ Subroutine rho_j_tau(GS_RT,rho_s,tau_s,j_s,grho_s,lrho_s)
 
 !  allocate(tau_s_l_omp(NL,0:NUMBER_THREADS-1),j_s_l_omp(NL,3,0:NUMBER_THREADS-1)) ! sato
   rho_s=rho*0.5d0
-  if(iflag_nlcc == 1)rho_s = rho_s + 0.5d0*rho_nlcc
+  if(flag_nlcc)rho_s = rho_s + 0.5d0*rho_nlcc
 
   tau_s_l_omp=0d0
   j_s_l_omp=0d0
@@ -1049,7 +1049,7 @@ Subroutine rho_j_tau(GS_RT,rho_s,tau_s,j_s,grho_s,lrho_s)
   call MPI_ALLREDUCE(tau_s_l,tau_s,NL,MPI_REAL8,MPI_SUM,NEW_COMM_WORLD,ierr)
   call MPI_ALLREDUCE(j_s_l,j_s,NL*3,MPI_REAL8,MPI_SUM,NEW_COMM_WORLD,ierr)
 
-  if(iflag_nlcc == 1)tau_s = tau_s + 0.5d0*tau_nlcc
+  if(flag_nlcc)tau_s = tau_s + 0.5d0*tau_nlcc
 
   select case(Nd)
   case(4)

--- a/common/Exc_Cor.f90
+++ b/common/Exc_Cor.f90
@@ -942,6 +942,7 @@ Subroutine rho_j_tau(GS_RT,rho_s,tau_s,j_s,grho_s,lrho_s)
 
 !  allocate(tau_s_l_omp(NL,0:NUMBER_THREADS-1),j_s_l_omp(NL,3,0:NUMBER_THREADS-1)) ! sato
   rho_s=rho*0.5d0
+  if(iflag_nlcc == 1)rho_s = rho_s + 0.5d0*rho_nlcc
 
   tau_s_l_omp=0d0
   j_s_l_omp=0d0
@@ -1047,6 +1048,8 @@ Subroutine rho_j_tau(GS_RT,rho_s,tau_s,j_s,grho_s,lrho_s)
 
   call MPI_ALLREDUCE(tau_s_l,tau_s,NL,MPI_REAL8,MPI_SUM,NEW_COMM_WORLD,ierr)
   call MPI_ALLREDUCE(j_s_l,j_s,NL*3,MPI_REAL8,MPI_SUM,NEW_COMM_WORLD,ierr)
+
+  if(iflag_nlcc == 1)tau_s = tau_s + 0.5d0*tau_nlcc
 
   select case(Nd)
   case(4)

--- a/common/Exc_Cor.f90
+++ b/common/Exc_Cor.f90
@@ -48,6 +48,7 @@ Subroutine Exc_Cor_PZ()
 !$acc kernels
 !  call rho_j_tau(GS_RT,rho_s,tau_s,j_s,grho_s,lrho_s)
   rho_s=rho*0.5d0
+  if(flag_nlcc)rho_s = rho_s + 0.5d0*rho_nlcc
 !!$omp parallel do private(i,trho,rs,V_xc,E_xc,rssq,rsln)
   do i=1,NL
     trho=2*rho_s(i)
@@ -77,6 +78,7 @@ Subroutine Exc_Cor_PZM()
 !$acc kernels
 !  call rho_j_tau(GS_RT,rho_s,tau_s,j_s,grho_s,lrho_s)
   rho_s=rho*0.5d0
+  if(flag_nlcc)rho_s = rho_s + 0.5d0*rho_nlcc
 !!$omp parallel do private(i,trho,rs,V_xc,E_xc,rssq,rsln)
   do i=1,NL
     trho=2*rho_s(i)

--- a/main/sc.f90
+++ b/main/sc.f90
@@ -1203,8 +1203,8 @@ subroutine prep_Reentrance_Read
   read(500) itable_sym(:,:) ! sym
   read(500) rho_l(:),rho_tmp1(:),rho_tmp2(:) !sym
 
-  read(500) iflag_nlcc
-  if(iflag_nlcc /= 0)then
+  read(500) flag_nlcc
+  if(flag_nlcc)then
      allocate(rho_nlcc(NL),tau_nlcc(NL))
      read(500)rho_nlcc(:),tau_nlcc(:)
   end if
@@ -1415,8 +1415,8 @@ subroutine prep_Reentrance_write
   write(500) rho_l(:),rho_tmp1(:),rho_tmp2(:) !sym
 
 
-  write(500) iflag_nlcc
-  if(iflag_nlcc /= 0)then
+  write(500) flag_nlcc
+  if(flag_nlcc)then
      write(500)rho_nlcc(:),tau_nlcc(:)
   end if
 

--- a/main/sc.f90
+++ b/main/sc.f90
@@ -1203,6 +1203,13 @@ subroutine prep_Reentrance_Read
   read(500) itable_sym(:,:) ! sym
   read(500) rho_l(:),rho_tmp1(:),rho_tmp2(:) !sym
 
+  read(500) iflag_nlcc
+  if(iflag_nlcc /= 0)then
+     allocate(rho_nlcc(NL),tau_nlcc(NL))
+     read(500)rho_nlcc(:),tau_nlcc(:)
+  end if
+
+
   call timelog_reentrance_read(500)
   call opt_vars_initialize_p1
   call opt_vars_initialize_p2
@@ -1406,6 +1413,12 @@ subroutine prep_Reentrance_write
 
   write(500) itable_sym(:,:) ! sym
   write(500) rho_l(:),rho_tmp1(:),rho_tmp2(:) !sym
+
+
+  write(500) iflag_nlcc
+  if(iflag_nlcc /= 0)then
+     write(500)rho_nlcc(:),tau_nlcc(:)
+  end if
 
   call timelog_reentrance_write(500)
 

--- a/modules/global_variables_ms.f90
+++ b/modules/global_variables_ms.f90
@@ -84,6 +84,10 @@ Module Global_Variables
   real(8),allocatable :: esp_vb_min(:),esp_vb_max(:) !FS set
   real(8),allocatable :: esp_cb_min(:),esp_cb_max(:) !FS set
   real(8),allocatable :: Eall_GS(:),esp_var_ave(:),esp_var_max(:),dns_diff(:)
+!Nonlinear core correction
+  integer :: iflag_nlcc = 0
+  real(8),allocatable :: rho_nlcc_tbl(:,:),tau_nlcc_tbl(:,:)
+  real(8),allocatable :: rho_nlcc(:),tau_nlcc(:)
 
 ! wave functions, work array
   complex(8),allocatable :: zu(:,:,:),zu_GS(:,:,:),zu_GS0(:,:,:)

--- a/modules/global_variables_ms.f90
+++ b/modules/global_variables_ms.f90
@@ -85,7 +85,7 @@ Module Global_Variables
   real(8),allocatable :: esp_cb_min(:),esp_cb_max(:) !FS set
   real(8),allocatable :: Eall_GS(:),esp_var_ave(:),esp_var_max(:),dns_diff(:)
 !Nonlinear core correction
-  integer :: iflag_nlcc = 0
+  logical :: flag_nlcc = .false.
   real(8),allocatable :: rho_nlcc_tbl(:,:),tau_nlcc_tbl(:,:)
   real(8),allocatable :: rho_nlcc(:),tau_nlcc(:)
 

--- a/modules/global_variables_sc.f90
+++ b/modules/global_variables_sc.f90
@@ -83,6 +83,10 @@ Module Global_Variables
   real(8),allocatable :: esp_vb_min(:),esp_vb_max(:) !FS set
   real(8),allocatable :: esp_cb_min(:),esp_cb_max(:) !FS set
   real(8),allocatable :: Eall_GS(:),esp_var_ave(:),esp_var_max(:),dns_diff(:)
+!Nonlinear core correction
+  integer :: iflag_nlcc = 0
+  real(8),allocatable :: rho_nlcc_tbl(:,:),tau_nlcc_tbl(:,:)
+  real(8),allocatable :: rho_nlcc(:),tau_nlcc(:)
 
 ! wave functions, work array
   complex(8),allocatable :: zu(:,:,:),zu_GS(:,:,:),zu_GS0(:,:,:)

--- a/modules/global_variables_sc.f90
+++ b/modules/global_variables_sc.f90
@@ -84,7 +84,7 @@ Module Global_Variables
   real(8),allocatable :: esp_cb_min(:),esp_cb_max(:) !FS set
   real(8),allocatable :: Eall_GS(:),esp_var_ave(:),esp_var_max(:),dns_diff(:)
 !Nonlinear core correction
-  integer :: iflag_nlcc = 0
+  logical :: flag_nlcc = .false.
   real(8),allocatable :: rho_nlcc_tbl(:,:),tau_nlcc_tbl(:,:)
   real(8),allocatable :: rho_nlcc(:),tau_nlcc(:)
 

--- a/preparation/input_ps.f90
+++ b/preparation/input_ps.f90
@@ -799,7 +799,7 @@ End Subroutine Read_PS_ABINIT
 Subroutine Read_PS_ABINITFHI(Lmax0,Nrmax0,Mr,rRC,upp,vpp,rhor_nlcc,flag_nlcc_element,ik,ps_file)
 !This is for  FHI pseudopotential listed in abinit web page and not for original FHI98PP.
 !See http://www.abinit.org/downloads/psp-links/lda_fhi
-  use Global_Variables,only : Nrmax,Lmax,Mlps,Zps,rad,flag_nlcc,pi,NE
+  use Global_Variables,only : Nrmax,Lmax,Mlps,Zps,rad,pi,NE
   implicit none
 !argument
   integer,intent(in) :: Lmax0,Nrmax0,ik

--- a/preparation/input_ps.f90
+++ b/preparation/input_ps.f90
@@ -231,6 +231,7 @@ Subroutine input_pseudopotential_YS
   CALL MPI_BCAST(Mass,NE,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
   CALL MPI_BCAST(rho_nlcc_tbl,Nrmax*NE,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
   CALL MPI_BCAST(tau_nlcc_tbl,Nrmax*NE,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
+  CALL MPI_BCAST(iflag_nlcc,NE,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
 
   return
   contains

--- a/preparation/prep_ps.f90
+++ b/preparation/prep_ps.f90
@@ -268,7 +268,7 @@ Subroutine prep_ps_periodic(property)
 ! nonlinear core-correction
   rho_nlcc = 0d0
   tau_nlcc = 0d0
-  if(iflag_nlcc == 1)then
+  if(flag_nlcc)then
     if(myrank == 0)write(*,"(A)")"Preparation: Non-linear core correction"
     do a=1,NI
       ik=Kion(a)

--- a/preparation/prep_ps.f90
+++ b/preparation/prep_ps.f90
@@ -34,6 +34,7 @@ Subroutine prep_ps_periodic(property)
   real(8) :: udVtbl_d(Nrmax,0:Lmax),dudVtbl_d(Nrmax,0:Lmax)
   real(8),allocatable :: xn(:),yn(:),an(:),bn(:),cn(:),dn(:)  
   real(8) :: vloc_av
+  real(8) :: ratio1,ratio2,rc
   if(property == 'not_initial') then
     deallocate(a_tbl,uV,duV,iuV,Jxyz,Jxx,Jyy,Jzz)
     deallocate(ekr) ! sato
@@ -263,6 +264,48 @@ Subroutine prep_ps_periodic(property)
     enddo
     deallocate(xn,yn,an,bn,cn,dn)
   enddo
+
+! nonlinear core-correction
+  rho_nlcc = 0d0
+  tau_nlcc = 0d0
+  if(iflag_nlcc == 1)then
+    if(myrank == 0)write(*,"(A)")"Preparation: Non-linear core correction"
+    do a=1,NI
+      ik=Kion(a)
+      rc = 15d0 ! maximum
+      do i=1,Nrmax
+        if(rho_nlcc_tbl(i,ik) + tau_nlcc_tbl(i,ik) < 1d-6)then
+          rc = rad(i,ik)
+          exit
+        end if
+        if(i == Nrmax) stop"no-cut-off"
+      end do
+      
+      do ix=-2,2; do iy=-2,2; do iz=-2,2
+        do i=1,NL
+          x=Lx(i)*Hx-(Rion(1,a)+ix*aLx)
+          y=Ly(i)*Hy-(Rion(2,a)+iy*aLy)
+          z=Lz(i)*Hz-(Rion(3,a)+iz*aLz)
+          r=sqrt(x**2+y**2+z**2)
+          if(r > rc)cycle
+          
+          do ir=1,NRmax
+            if(rad(ir,ik).gt.r) exit
+          enddo
+          intr=ir-1
+          if (intr.lt.0.or.intr.ge.NRmax)stop 'bad intr at prep_ps'
+          ratio1=(r-rad(intr,ik))/(rad(intr+1,ik)-rad(intr,ik))
+          ratio2=1-ratio1
+          rho_nlcc(i) = rho_nlcc(i) &
+            +ratio1*rho_nlcc_tbl(intr+1,ik)+ratio2*rho_nlcc_tbl(intr,ik)
+          tau_nlcc(i) = tau_nlcc(i) &
+            +ratio1*tau_nlcc_tbl(intr+1,ik)+ratio2*tau_nlcc_tbl(intr,ik)
+          
+        enddo
+        
+      end do; end do; end do
+    end do
+  end if
 
   return
 End Subroutine prep_ps_periodic


### PR DESCRIPTION
The nonlinear core correction is implemented for the ABINITFHI pseudopotential format. The correction for the meta-GGA is correct only if pseudopotentials are provided by "APE" program.