### PR TITLE
Multiscale calculation for 2D/cylindal coordinate system

### DIFF
--- a/FDTD/CMakeLists.txt
+++ b/FDTD/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+    beam.f90
     FDTD.f90
     )
 

--- a/FDTD/FDTD.f90
+++ b/FDTD/FDTD.f90
@@ -51,7 +51,7 @@ subroutine write_result_all()
   ! (written by M.Uemoto on 2016-11-22)
   Ndata = Nt / Nstep_write
   Ndata_per_proc = ceiling(float(Ndata) / Nprocs)
-  do i=0, Ndata_per_proc
+  do i=0, Ndata_per_proc-1
     index = Myrank * Ndata_per_proc + i
     if (index <= Ndata) then
       call write_result(index)
@@ -126,7 +126,7 @@ subroutine init_Ac_ms_2dc()
   j_m=0d0
   jmatter_m=0d0
   jmatter_m_l=0d0
-  energy_joule=0.0
+  energy_joule=0d0
   call incident_bessel_beam()
   
   call MPI_BARRIER(MPI_COMM_WORLD,ierr)
@@ -352,11 +352,11 @@ subroutine dt_evolve_Ac_1d
   Ac_old_m=Ac_m
   Ac_m=Ac_new_m
   do ix_m=NXvacL_m,NXvacR_m
-    RR(1) = 0.0
+    RR(1) = 0.0d0
     RR(2) = -(Ac_m(2,ix_m+1,1) - 2*Ac_m(2,ix_m,1) + Ac_m(2,ix_m-1,1)) * (1.0 / HX_m**2) 
     RR(3) = -(Ac_m(3,ix_m+1,1) - 2*Ac_m(3,ix_m,1) + Ac_m(3,ix_m-1,1)) * (1.0 / HX_m**2) 
     Ac_new_m(:,ix_m,1) = (2*Ac_m(:,ix_m,1) - Ac_old_m(:,ix_m,1) &
-      & - j_m(:,ix_m,1)*4.0*pi*(dt**2) - RR(:)*(c_light*dt)**2 )
+      & - j_m(:,ix_m,1)*4.0d0*pi*(dt**2) - RR(:)*(c_light*dt)**2 )
   end do
   return
 end subroutine dt_evolve_Ac_1d
@@ -373,25 +373,25 @@ subroutine dt_evolve_Ac_2d
   Ac_m=Ac_new_m
   do iy_m=NYvacB_m,NYvacT_m
     do ix_m=NXvacL_m,NXvacR_m
-      RR(1) = +(-1.00/HY_m**2) * Ac_m(1, ix_m, iy_m-1) &
-            & +(+2.00/HY_m**2) * Ac_m(1, ix_m, iy_m) &
-            & +(-1.00/HY_m**2) * Ac_m(1, ix_m, iy_m+1) &
-            & +(+0.25/HX_m/HY_m) * Ac_m(2, ix_m-1, iy_m-1) &
-            & +(-0.25/HX_m/HY_m) * Ac_m(2, ix_m-1, iy_m+1) &
-            & +(-0.25/HX_m/HY_m) * Ac_m(2, ix_m+1, iy_m-1) &
-            & +(+0.25/HX_m/HY_m) * Ac_m(2, ix_m+1, iy_m+1)
-      RR(2) = +(+0.25/HX_m/HY_m) * Ac_m(1, ix_m-1, iy_m-1) &
-            & +(-0.25/HX_m/HY_m) * Ac_m(1, ix_m-1, iy_m+1) &
-            & +(-0.25/HX_m/HY_m) * Ac_m(1, ix_m+1, iy_m-1) &
-            & +(+0.25/HX_m/HY_m) * Ac_m(1, ix_m+1, iy_m+1) &
-            & +(-1.00/HX_m**2) * Ac_m(2, ix_m-1, iy_m) &
-            & +(+2.00/HX_m**2) * Ac_m(2, ix_m, iy_m) &
-            & +(-1.00/HX_m**2) * Ac_m(2, ix_m+1, iy_m)
-      RR(3) = +(-1.00/HX_m**2) * Ac_m(3, ix_m-1, iy_m) &
-            & +(-1.00/HY_m**2) * Ac_m(3, ix_m, iy_m-1) &
-            & +(+2.00/HY_m**2 +2.00/HX_m**2) * Ac_m(3, ix_m, iy_m) &
-            & +(-1.00/HY_m**2) * Ac_m(3, ix_m, iy_m+1) &
-            & +(-1.00/HX_m**2) * Ac_m(3, ix_m+1, iy_m)
+      RR(1) = +(-1.00d0/HY_m**2) * Ac_m(1, ix_m, iy_m-1) &
+            & +(+2.00d0/HY_m**2) * Ac_m(1, ix_m, iy_m) &
+            & +(-1.00d0/HY_m**2) * Ac_m(1, ix_m, iy_m+1) &
+            & +(+0.25d0/HX_m/HY_m) * Ac_m(2, ix_m-1, iy_m-1) &
+            & +(-0.25d0/HX_m/HY_m) * Ac_m(2, ix_m-1, iy_m+1) &
+            & +(-0.25d0/HX_m/HY_m) * Ac_m(2, ix_m+1, iy_m-1) &
+            & +(+0.25d0/HX_m/HY_m) * Ac_m(2, ix_m+1, iy_m+1)
+      RR(2) = +(+0.25d0/HX_m/HY_m) * Ac_m(1, ix_m-1, iy_m-1) &
+            & +(-0.25d0/HX_m/HY_m) * Ac_m(1, ix_m-1, iy_m+1) &
+            & +(-0.25d0/HX_m/HY_m) * Ac_m(1, ix_m+1, iy_m-1) &
+            & +(+0.25d0/HX_m/HY_m) * Ac_m(1, ix_m+1, iy_m+1) &
+            & +(-1.00d0/HX_m**2) * Ac_m(2, ix_m-1, iy_m) &
+            & +(+2.00d0/HX_m**2) * Ac_m(2, ix_m, iy_m) &
+            & +(-1.00d0/HX_m**2) * Ac_m(2, ix_m+1, iy_m)
+      RR(3) = +(-1.00d0/HX_m**2) * Ac_m(3, ix_m-1, iy_m) &
+            & +(-1.00d0/HY_m**2) * Ac_m(3, ix_m, iy_m-1) &
+            & +(+2.00d0/HY_m**2 +2.00d0/HX_m**2) * Ac_m(3, ix_m, iy_m) &
+            & +(-1.00d0/HY_m**2) * Ac_m(3, ix_m, iy_m+1) &
+            & +(-1.00d0/HX_m**2) * Ac_m(3, ix_m+1, iy_m)
       Ac_new_m(:,ix_m,iy_m) = (2 * Ac_m(:,ix_m,iy_m) - Ac_old_m(:,ix_m,iy_m) &
         & -j_m(:,ix_m,iy_m) * 4.0*pi*(dt**2) - RR(:)*(c_light*dt)**2 )
     end do
@@ -403,7 +403,7 @@ subroutine dt_evolve_Ac_2d
     Ac_new_m(:,:,NYvacT_m+1)=Ac_new_m(:,:,NYvacB_m)
   case('isolated')
     Ac_new_m(:,:,NYvacB_m-1)=Ac_new_m(:,:,NYvacB_m)
-    Ac_new_m(:,:,NYvacT_m+1)=0.0
+    Ac_new_m(:,:,NYvacT_m+1)=0.0d0
   end select
   return
 end subroutine dt_evolve_Ac_2d
@@ -419,36 +419,36 @@ subroutine dt_evolve_Ac_2dc()
   Ac_old_m=Ac_m
   Ac_m=Ac_new_m
   do iy_m=NYvacB_m,NYvacT_m
-    Y = (iy_m - 0.5) * HY_m
+    Y = (iy_m - 0.50d0) * HY_m
     do ix_m=NXvacL_m,NXvacR_m
-      RR(1) = +(+0.50*(1.00/HY_m)*(1.00/Y)-(1.00/HY_m**2))*Ac_m(1,ix_m+0,iy_m-1) &
-            & +2.00*(1.00/HY_m**2)*Ac_m(1,ix_m+0,iy_m+0) &
-            & +(-0.50*(1.00/HY_m)*(1.00/Y)-(1.00/HY_m**2))*Ac_m(1,ix_m+0,iy_m+1) &
-            & +0.25*(1.00/(HX_m*HY_m))*Ac_m(2,ix_m-1,iy_m-1) &
-            & -0.50*(1.00/HX_m)*(1.00/Y)*Ac_m(2,ix_m-1,iy_m+0) &
-            & -0.25*(1.00/(HX_m*HY_m))*Ac_m(2,ix_m-1,iy_m+1) &
-            & -0.25*(1.00/(HX_m*HY_m))*Ac_m(2,ix_m+1,iy_m-1) &
-            & +0.50*(1.00/HX_m)*(1.00/Y)*Ac_m(2,ix_m+1,iy_m+0) &
-            & +0.25*(1.00/(HX_m*HY_m))*Ac_m(2,ix_m+1,iy_m+1)
-      RR(2) = +0.25*(1.00/(HX_m*HY_m))*Ac_m(1,ix_m-1,iy_m-1) &
-            & -0.25*(1.00/(HX_m*HY_m))*Ac_m(1,ix_m-1,iy_m+1) &
-            & -0.25*(1.00/(HX_m*HY_m))*Ac_m(1,ix_m+1,iy_m-1) &
-            & +0.25*(1.00/(HX_m*HY_m))*Ac_m(1,ix_m+1,iy_m+1) &
-            & -(1.00/HX_m**2)*Ac_m(2,ix_m-1,iy_m+0) &
-            & +2.00*(1.00/HX_m**2)*Ac_m(2,ix_m+0,iy_m+0) &
-            & -(1.00/HX_m**2)*Ac_m(2,ix_m+1,iy_m+0)
-      RR(3) = -(1.00/HX_m**2)*Ac_m(3,ix_m-1,iy_m+0) &
-            & +(+0.50*(1.00/HY_m)*(1.00/Y)-(1.00/HY_m**2))*Ac_m(3,ix_m+0,iy_m-1) &
-            & +(+(1.00/Y**2)+2.00*(1.00/HX_m**2)+2.00*(1.00/HY_m**2))*Ac_m(3,ix_m+0,iy_m+0) &
-            & +(-0.50*(1.00/HY_m)*(1.00/Y)-(1.00/HY_m**2))*Ac_m(3,ix_m+0,iy_m+1) &
-            & -(1.00/HX_m**2)*Ac_m(3,ix_m+1,iy_m+0)
+      RR(1) = +(+0.50d0*(1.00d0/HY_m)*(1.00d0/Y)-(1.00d0/HY_m**2))*Ac_m(1,ix_m+0,iy_m-1) &
+            & +2.00d0*(1.00d0/HY_m**2)*Ac_m(1,ix_m+0,iy_m+0) &
+            & +(-0.50d0*(1.00d0/HY_m)*(1.00d0/Y)-(1.00d0/HY_m**2))*Ac_m(1,ix_m+0,iy_m+1) &
+            & +0.25d0*(1.00d0/(HX_m*HY_m))*Ac_m(2,ix_m-1,iy_m-1) &
+            & -0.50d0*(1.00d0/HX_m)*(1.00d0/Y)*Ac_m(2,ix_m-1,iy_m+0) &
+            & -0.25d0*(1.00d0/(HX_m*HY_m))*Ac_m(2,ix_m-1,iy_m+1) &
+            & -0.25d0*(1.00d0/(HX_m*HY_m))*Ac_m(2,ix_m+1,iy_m-1) &
+            & +0.50d0*(1.00d0/HX_m)*(1.00d0/Y)*Ac_m(2,ix_m+1,iy_m+0) &
+            & +0.25d0*(1.00d0/(HX_m*HY_m))*Ac_m(2,ix_m+1,iy_m+1)
+      RR(2) = +0.25d0*(1.00d0/(HX_m*HY_m))*Ac_m(1,ix_m-1,iy_m-1) &
+            & -0.25d0*(1.00d0/(HX_m*HY_m))*Ac_m(1,ix_m-1,iy_m+1) &
+            & -0.25d0*(1.00d0/(HX_m*HY_m))*Ac_m(1,ix_m+1,iy_m-1) &
+            & +0.25d0*(1.00d0/(HX_m*HY_m))*Ac_m(1,ix_m+1,iy_m+1) &
+            & -(1.00d0/HX_m**2)*Ac_m(2,ix_m-1,iy_m+0) &
+            & +2.00d0*(1.00d0/HX_m**2)*Ac_m(2,ix_m+0,iy_m+0) &
+            & -(1.00d0/HX_m**2)*Ac_m(2,ix_m+1,iy_m+0)
+      RR(3) = -(1.00d0/HX_m**2)*Ac_m(3,ix_m-1,iy_m+0) &
+            & +(+0.50d0*(1.00d0/HY_m)*(1.00d0/Y)-(1.00d0/HY_m**2))*Ac_m(3,ix_m+0,iy_m-1) &
+            & +(+(1.00d0/Y**2)+2.00d0*(1.00d0/HX_m**2)+2.00d0*(1.00d0/HY_m**2))*Ac_m(3,ix_m+0,iy_m+0) &
+            & +(-0.50d0*(1.00d0/HY_m)*(1.00d0/Y)-(1.00d0/HY_m**2))*Ac_m(3,ix_m+0,iy_m+1) &
+            & -(1.00d0/HX_m**2)*Ac_m(3,ix_m+1,iy_m+0)
       Ac_new_m(:,ix_m,iy_m) = (2 * Ac_m(:,ix_m,iy_m) - Ac_old_m(:,ix_m,iy_m) &
         & -J_m(:,ix_m,iy_m) * 4.0*pi*(dt**2) - RR(:)*(c_light*dt)**2 )
     end do
   end do
   ! Boundary condition
   Ac_new_m(:,:,NYvacB_m-1)=Ac_new_m(:,:,NYvacB_m)
-  Ac_new_m(:,:,NYvacT_m+1)=0.0
+  Ac_new_m(:,:,NYvacT_m+1)=0.0d0
   return
 end subroutine dt_evolve_Ac_2dc
 !===========================================================
@@ -496,7 +496,7 @@ subroutine calc_bmag_field_1d()
   ! calculate the magnetic field from the vector potential (1D case)
   ! (written by M.Uemoto on 2016-11-22)
   do ix_m=NXvacL_m, NXvacR_m
-    Rc(1) = 0.0
+    Rc(1) = 0.0d0
     Rc(2) = - (Ac_m(3,ix_m+1,1) - Ac_m(3,ix_m-1,1)) / (2 * HX_m)
     Rc(3) = + (Ac_m(2,ix_m+1,1) - Ac_m(2,ix_m-1,1)) / (2 * HX_m)
     Bmag(:,ix_m,1) = Rc(:) * c_light
@@ -535,17 +535,17 @@ subroutine calc_bmag_field_2dc()
   ! calculate the magnetic field from the vector potential (2D cylindal case)
   ! (written by M.Uemoto on 2016-11-22)
   do iy_m=NYvacB_m, NYvacT_m
-    Y = (iy_m-0.5) * HY_m
+    Y = (iy_m-0.5d0) * HY_m
     do ix_m=NXvacL_m, NXvacR_m
-      Rc(1) = -0.50*(1.00/HY_m)*Ac_m(3,ix_m+0,iy_m-1) &
-            & +1.00*(1.00/Y)*Ac_m(3,ix_m+0,iy_m+0) &
-            & +0.50*(1.00/HY_m)*Ac_m(3,ix_m+0,iy_m+1)
-      Rc(2) = +0.50*(1.00/HX_m)*Ac_m(3,ix_m-1,iy_m+0) &
-            & -0.50*(1.00/HX_m)*Ac_m(3,ix_m+1,iy_m+0)
-      Rc(3) = +0.50*(1.00/HY_m)*Ac_m(1,ix_m+0,iy_m-1) &
-            & -0.50*(1.00/HY_m)*Ac_m(1,ix_m+0,iy_m+1) &
-            & -0.50*(1.00/HX_m)*Ac_m(2,ix_m-1,iy_m+0) &
-            & +0.50*(1.00/HX_m)*Ac_m(2,ix_m+1,iy_m+0)
+      Rc(1) = -0.50d0*(1.00d0/HY_m)*Ac_m(3,ix_m+0,iy_m-1) &
+            & +1.00d0*(1.00d0/Y)*Ac_m(3,ix_m+0,iy_m+0) &
+            & +0.50d0*(1.00d0/HY_m)*Ac_m(3,ix_m+0,iy_m+1)
+      Rc(2) = +0.50d0*(1.00d0/HX_m)*Ac_m(3,ix_m-1,iy_m+0) &
+            & -0.50d0*(1.00d0/HX_m)*Ac_m(3,ix_m+1,iy_m+0)
+      Rc(3) = +0.50d0*(1.00d0/HY_m)*Ac_m(1,ix_m+0,iy_m-1) &
+            & -0.50d0*(1.00d0/HY_m)*Ac_m(1,ix_m+0,iy_m+1) &
+            & -0.50d0*(1.00d0/HX_m)*Ac_m(2,ix_m-1,iy_m+0) &
+            & +0.50d0*(1.00d0/HX_m)*Ac_m(2,ix_m+1,iy_m+0)
       Bmag(:,ix_m,iy_m) = Rc(:) * c_light
     end do
   end do

--- a/FDTD/FDTD.f90
+++ b/FDTD/FDTD.f90
@@ -13,78 +13,52 @@
 !  See the License for the specific language governing permissions and
 !  limitations under the License.
 !
-subroutine write_result_all
+
+!===============================================================
+subroutine write_result(index)
   use Global_Variables
   implicit none
-  integer :: iter_t,iter_i
-  integer ix_m,iy_m
-  character(30) wf,citer
-
-  do iter_i=0,Nt/Nstep_write
-
-    if(myrank == mod(iter_i,Nprocs)) then
-      iter_t=iter_i*Nstep_write
-      write(citer,'(I6.6)')iter_t
-      wf=trim(directory)//trim(SYSname) &
-        &//'_Ac_'//trim(citer)//'.out'
-      open(902,file=wf)
-
-      if(NY_m==1) then
-        do ix_m=NXvacL_m,NXvacR_m
-          write(902,'(10e26.16E3)') ix_m*HX_m,data_out(1:9,ix_m,1,iter_i)
-        end do
-      else
-        do iy_m=1,NY_m
-          do ix_m=NXvacL_m,NXvacR_m
-            write(902,'(11e26.16E3)') ix_m*HX_m,iy_m*HY_m,data_out(1:9,ix_m,iy_m,iter_i)
-          end do
-        end do
-      end if
-      close(902)
-    end if
-! 1000 format(1x,2(1pe10.3,1x))
+  integer, intent(in) :: index
+  integer :: iter,ix_m,iy_m
+  ! export results of each calculation step
+  ! (written by M.Uemoto on 2016-11-22)
+  iter = Nstep_write * index
+  write(file_ac, "(A,A,'_Ac_',I6.6,'.out')") trim(directory), trim(SYSname), iter 
+  open(902, file=file_ac)
+  select case(FDTDdim)
+  case("1D")
+    write(902,*) "# X Acx Acy Acz Ex Ey Ez Bx By Bz Jx Jy Jz E(EM) E(J) E(Mat) E(Tot)"
+    do ix_m=NXvacL_m,NXvacR_m
+      write(902,'(17e26.16E3)') ix_m*HX_m, data_out(1:16,ix_m,1,index)
+    end do
+  case("2D", "2DC")
+    write(902,*) "# X Y Acx Acy Acz Ex Ey Ez Bx By Bz Jx Jy Jz E_EM E_J E_Mat E_Tot"
+    do iy_m=NYvacB_m,NYvacT_m
+      do ix_m=NXvacL_m,NXvacR_m
+        write(902,'(18e26.16E3)') ix_m*HX_m,iy_m*HY_m,data_out(1:16,ix_m,iy_m,index)
+      end do
+    end do
+  end select
+  close(902)
+  return
+end subroutine write_result
+!===============================================================
+subroutine write_result_all()
+  use Global_Variables
+  implicit none
+  integer :: Ndata, Ndata_per_proc, i, index
+  ! export all results by using MPI
+  ! (written by M.Uemoto on 2016-11-22)
+  Ndata = Nt / Nstep_write
+  Ndata_per_proc = ceiling(float(Ndata) / Nprocs)
+  do i=0, Ndata_per_proc
+    index = Myrank * Ndata_per_proc + i
+    if (index <= Ndata) then
+      call write_result(index)
+    endif
   end do
   return
 end subroutine write_result_all
-!===============================================================
-subroutine write_result(iter)
-  use Global_Variables
-  implicit none
-  integer i1,i2,i3,i4,i5,i6,i7,i8
-  integer iter,ix_m,iy_m
-  character(30) wf
-  
-  i1=iter/10000
-  i2=mod(iter,10000)
-  i3=i2/1000
-  i4=mod(i2,1000)
-  i5=i4/100
-  i6=mod(i4,100)
-  i7=i6/10
-  i8=mod(i6,10)
-  wf=trim(directory)//trim(SYSname) &
-       &//'_Ac_'//char(48+i1)//char(48+i3)//char(48+i5)//char(48+i7)//char(48+i8)//'.out'
-  open(902,file=wf)
-
-  if(NY_m==1) then
-    do ix_m=NXvacL_m,NXvacR_m
-      write(902,'(10e26.16E3)') ix_m*HX_m,Ac_new_m(2,ix_m,1),Ac_new_m(3,ix_m,1) &
-        &,Elec(2,ix_m,1),Elec(3,ix_m,1),j_m(2,ix_m,1),j_m(3,ix_m,1) &
-        &,energy_elemag(ix_m,1),energy_elec(ix_m,1),energy_total(ix_m,1)
-    end do
-  else
-    do iy_m=1,NY_m
-      do ix_m=NXvacL_m,NXvacR_m
-        write(902,'(11e26.16E3)') ix_m*HX_m,iy_m*HY_m,Ac_new_m(2,ix_m,iy_m),Ac_new_m(3,ix_m,iy_m) &
-          &,Elec(2,ix_m,iy_m),Elec(3,ix_m,iy_m),j_m(2,ix_m,iy_m),j_m(3,ix_m,iy_m) &
-          &,energy_elemag(ix_m,iy_m),energy_elec(ix_m,iy_m),energy_total(ix_m,iy_m) 
-      end do
-    end do
-  end if
-  close(902)
-! 1000 format(1x,2(1pe10.3,1x))
-  return
-end subroutine write_result
 !===============================================================
 subroutine write_energy(iter)
   use Global_Variables
@@ -142,6 +116,23 @@ subroutine write_excited_electron(iter)
   return
 end subroutine write_excited_electron
 !===============================================================
+subroutine init_Ac_ms_2dc()
+  use Global_variables
+  implicit none
+  ! initialization for 2D cylinder mode
+  ! (written by M.Uemoto on 2016-11-22)
+  Elec=0d0
+  Bmag=0d0
+  j_m=0d0
+  jmatter_m=0d0
+  jmatter_m_l=0d0
+  energy_joule=0.0
+  call incident_bessel_beam()
+  
+  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  return
+end subroutine init_Ac_ms_2dc
+!===============================================================
 subroutine init_Ac_ms
   use Global_variables
   implicit none
@@ -180,6 +171,7 @@ subroutine init_Ac_ms
   j_m=0d0
   jmatter_m=0d0
   jmatter_m_l=0d0      
+  energy_joule=0.0
       
   Ac_m=0d0
   Ac_old_m=0d0
@@ -346,60 +338,264 @@ subroutine init_Ac_ms
   case default
     stop 'boundary condition is not good'
   end select
-  
-
   return
 end subroutine init_Ac_ms
+!===========================================================
+subroutine dt_evolve_Ac_1d
+  use Global_variables, only: Ac_old_m, Ac_m, Ac_new_m, &
+                            & NXvacL_m,NXvacR_m, HX_m, dt, &
+                            & j_m, c_light, pi, c_light  
+  implicit none
+  integer :: ix_m
+  real(8) :: RR(3) ! rot rot Ac
+
+  Ac_old_m=Ac_m
+  Ac_m=Ac_new_m
+  do ix_m=NXvacL_m,NXvacR_m
+    RR(1) = 0.0
+    RR(2) = -(Ac_m(2,ix_m+1,1) - 2*Ac_m(2,ix_m,1) + Ac_m(2,ix_m-1,1)) * (1.0 / HX_m**2) 
+    RR(3) = -(Ac_m(3,ix_m+1,1) - 2*Ac_m(3,ix_m,1) + Ac_m(3,ix_m-1,1)) * (1.0 / HX_m**2) 
+    Ac_new_m(:,ix_m,1) = (2*Ac_m(:,ix_m,1) - Ac_old_m(:,ix_m,1) &
+      & - j_m(:,ix_m,1)*4.0*pi*(dt**2) - RR(:)*(c_light*dt)**2 )
+  end do
+  return
+end subroutine dt_evolve_Ac_1d
+!===========================================================
+subroutine dt_evolve_Ac_2d
+  use Global_variables, only: Ac_old_m, Ac_m, Ac_new_m, &
+                            & NYvacB_m,NYvacT_m,NXvacL_m,NXvacR_m, TwoD_shape, &
+                            & HX_m, HY_m, dt, j_m, c_light, pi, c_light
+  implicit none
+  integer :: ix_m,iy_m
+  real(8) :: RR(3) ! rot rot Ac
+  ! (written by M.Uemoto on 2016-11-22)
+  Ac_old_m=Ac_m
+  Ac_m=Ac_new_m
+  do iy_m=NYvacB_m,NYvacT_m
+    do ix_m=NXvacL_m,NXvacR_m
+      RR(1) = +(-1.00/HY_m**2) * Ac_m(1, ix_m, iy_m-1) &
+            & +(+2.00/HY_m**2) * Ac_m(1, ix_m, iy_m) &
+            & +(-1.00/HY_m**2) * Ac_m(1, ix_m, iy_m+1) &
+            & +(+0.25/HX_m/HY_m) * Ac_m(2, ix_m-1, iy_m-1) &
+            & +(-0.25/HX_m/HY_m) * Ac_m(2, ix_m-1, iy_m+1) &
+            & +(-0.25/HX_m/HY_m) * Ac_m(2, ix_m+1, iy_m-1) &
+            & +(+0.25/HX_m/HY_m) * Ac_m(2, ix_m+1, iy_m+1)
+      RR(2) = +(+0.25/HX_m/HY_m) * Ac_m(1, ix_m-1, iy_m-1) &
+            & +(-0.25/HX_m/HY_m) * Ac_m(1, ix_m-1, iy_m+1) &
+            & +(-0.25/HX_m/HY_m) * Ac_m(1, ix_m+1, iy_m-1) &
+            & +(+0.25/HX_m/HY_m) * Ac_m(1, ix_m+1, iy_m+1) &
+            & +(-1.00/HX_m**2) * Ac_m(2, ix_m-1, iy_m) &
+            & +(+2.00/HX_m**2) * Ac_m(2, ix_m, iy_m) &
+            & +(-1.00/HX_m**2) * Ac_m(2, ix_m+1, iy_m)
+      RR(3) = +(-1.00/HX_m**2) * Ac_m(3, ix_m-1, iy_m) &
+            & +(-1.00/HY_m**2) * Ac_m(3, ix_m, iy_m-1) &
+            & +(+2.00/HY_m**2 +2.00/HX_m**2) * Ac_m(3, ix_m, iy_m) &
+            & +(-1.00/HY_m**2) * Ac_m(3, ix_m, iy_m+1) &
+            & +(-1.00/HX_m**2) * Ac_m(3, ix_m+1, iy_m)
+      Ac_new_m(:,ix_m,iy_m) = (2 * Ac_m(:,ix_m,iy_m) - Ac_old_m(:,ix_m,iy_m) &
+        & -j_m(:,ix_m,iy_m) * 4.0*pi*(dt**2) - RR(:)*(c_light*dt)**2 )
+    end do
+  end do
+  ! Boundary Condition
+  select case(TwoD_shape)
+  case('periodic')
+    Ac_new_m(:,:,NYvacB_m-1)=Ac_new_m(:,:,NYvacT_m)
+    Ac_new_m(:,:,NYvacT_m+1)=Ac_new_m(:,:,NYvacB_m)
+  case('isolated')
+    Ac_new_m(:,:,NYvacB_m-1)=Ac_new_m(:,:,NYvacB_m)
+    Ac_new_m(:,:,NYvacT_m+1)=0.0
+  end select
+  return
+end subroutine dt_evolve_Ac_2d
+!===========================================================
+subroutine dt_evolve_Ac_2dc()
+  use Global_variables, only: Ac_old_m, Ac_m, Ac_new_m, &
+                            & NYvacB_m, NYvacT_m, NXvacL_m, NXvacR_m, &
+                            & HX_m, HY_m, dt, j_m, c_light, pi, c_light
+  implicit none
+  integer :: ix_m, iy_m
+  real(8) :: Y, RR(3) ! rot rot Ac
+  ! (written by M.Uemoto on 2016-11-22)
+  Ac_old_m=Ac_m
+  Ac_m=Ac_new_m
+  do iy_m=NYvacB_m,NYvacT_m
+    Y = (iy_m - 0.5) * HY_m
+    do ix_m=NXvacL_m,NXvacR_m
+      RR(1) = +(+0.50*(1.00/HY_m)*(1.00/Y)-(1.00/HY_m**2))*Ac_m(1,ix_m+0,iy_m-1) &
+            & +2.00*(1.00/HY_m**2)*Ac_m(1,ix_m+0,iy_m+0) &
+            & +(-0.50*(1.00/HY_m)*(1.00/Y)-(1.00/HY_m**2))*Ac_m(1,ix_m+0,iy_m+1) &
+            & +0.25*(1.00/(HX_m*HY_m))*Ac_m(2,ix_m-1,iy_m-1) &
+            & -0.50*(1.00/HX_m)*(1.00/Y)*Ac_m(2,ix_m-1,iy_m+0) &
+            & -0.25*(1.00/(HX_m*HY_m))*Ac_m(2,ix_m-1,iy_m+1) &
+            & -0.25*(1.00/(HX_m*HY_m))*Ac_m(2,ix_m+1,iy_m-1) &
+            & +0.50*(1.00/HX_m)*(1.00/Y)*Ac_m(2,ix_m+1,iy_m+0) &
+            & +0.25*(1.00/(HX_m*HY_m))*Ac_m(2,ix_m+1,iy_m+1)
+      RR(2) = +0.25*(1.00/(HX_m*HY_m))*Ac_m(1,ix_m-1,iy_m-1) &
+            & -0.25*(1.00/(HX_m*HY_m))*Ac_m(1,ix_m-1,iy_m+1) &
+            & -0.25*(1.00/(HX_m*HY_m))*Ac_m(1,ix_m+1,iy_m-1) &
+            & +0.25*(1.00/(HX_m*HY_m))*Ac_m(1,ix_m+1,iy_m+1) &
+            & -(1.00/HX_m**2)*Ac_m(2,ix_m-1,iy_m+0) &
+            & +2.00*(1.00/HX_m**2)*Ac_m(2,ix_m+0,iy_m+0) &
+            & -(1.00/HX_m**2)*Ac_m(2,ix_m+1,iy_m+0)
+      RR(3) = -(1.00/HX_m**2)*Ac_m(3,ix_m-1,iy_m+0) &
+            & +(+0.50*(1.00/HY_m)*(1.00/Y)-(1.00/HY_m**2))*Ac_m(3,ix_m+0,iy_m-1) &
+            & +(+(1.00/Y**2)+2.00*(1.00/HX_m**2)+2.00*(1.00/HY_m**2))*Ac_m(3,ix_m+0,iy_m+0) &
+            & +(-0.50*(1.00/HY_m)*(1.00/Y)-(1.00/HY_m**2))*Ac_m(3,ix_m+0,iy_m+1) &
+            & -(1.00/HX_m**2)*Ac_m(3,ix_m+1,iy_m+0)
+      Ac_new_m(:,ix_m,iy_m) = (2 * Ac_m(:,ix_m,iy_m) - Ac_old_m(:,ix_m,iy_m) &
+        & -J_m(:,ix_m,iy_m) * 4.0*pi*(dt**2) - RR(:)*(c_light*dt)**2 )
+    end do
+  end do
+  ! Boundary condition
+  Ac_new_m(:,:,NYvacB_m-1)=Ac_new_m(:,:,NYvacB_m)
+  Ac_new_m(:,:,NYvacT_m+1)=0.0
+  return
+end subroutine dt_evolve_Ac_2dc
 !===========================================================
 subroutine dt_evolve_Ac
   use Global_variables
   use timelog
   implicit none
-  integer ix_m,iy_m
-
+  ! (written by M.Uemoto on 2016-11-22)
   call timelog_begin(LOG_DT_EVOLVE_AC)
-
-  Ac_old_m=Ac_m
-  Ac_m=Ac_new_m
-
-
-!  if(iter/=0)then
-    do iy_m=1,NY_m
-      do ix_m=NXvacL_m+1,NXvacR_m-1
-        Ac_new_m(2,ix_m,iy_m)=2d0*Ac_m(2,ix_m,iy_m)-Ac_old_m(2,ix_m,iy_m)+(c_light*dt/HX_m)**2 &
-          &*(Ac_m(2,ix_m+1,iy_m)-2*Ac_m(2,ix_m,iy_m)+Ac_m(2,ix_m-1,iy_m))+(c_light*dt/HY_m)**2 &
-          &*(Ac_m(2,ix_m,iy_m+1)-2*Ac_m(2,ix_m,iy_m)+Ac_m(2,ix_m,iy_m-1))-4*pi*dt*dt*j_m(2,ix_m,iy_m)
-
-        Ac_new_m(3,ix_m,iy_m)=2d0*Ac_m(3,ix_m,iy_m)-Ac_old_m(3,ix_m,iy_m)+(c_light*dt/HX_m)**2 &
-          &*(Ac_m(3,ix_m+1,iy_m)-2*Ac_m(3,ix_m,iy_m)+Ac_m(3,ix_m-1,iy_m))+(c_light*dt/HY_m)**2 &
-          &*(Ac_m(3,ix_m,iy_m+1)-2*Ac_m(3,ix_m,iy_m)+Ac_m(3,ix_m,iy_m-1))-4*pi*dt*dt*j_m(3,ix_m,iy_m)
-      end do
-    enddo
-!  else
-!    do iy_m=1,NY_m
-!      do ix_m=NXvacL_m+1,NXvacR_m-1
-!        Ac_new_m(2,ix_m,iy_m)=Ac_m(2,ix_m,iy_m)+dt*g(2,ix_m,iy_m)+0.5d0*(c*dt/HX_m)**2 &
-!          *(Ac_m(2,ix_m+1,iy_m)-2*Ac_m(2,ix_m,iy_m)+Ac_m(2,ix_m-1,iy_m))+0.5d0*(c*dt/HY_m)**2 &
-!          *(Ac_m(2,ix_m,iy_m+1)-2*Ac_m(2,ix_m,iy_m)+Ac_m(2,ix_m,iy_m-1))-4*pi*dt*dt*j_m(2,ix_m,iy_m) 
-!
-!        Ac_new_m(3,ix_m,iy_m)=Ac_m(3,ix_m,iy_m)+dt*g(3,ix_m,iy_m)+0.5d0*(c*dt/HX_m)**2 &
-!          *(Ac_m(3,ix_m+1,iy_m)-2*Ac_m(3,ix_m,iy_m)+Ac_m(3,ix_m-1,iy_m))+0.5d0*(c*dt/HY_m)**2 &
-!          *(Ac_m(3,ix_m,iy_m+1)-2*Ac_m(3,ix_m,iy_m)+Ac_m(3,ix_m,iy_m-1))-4*pi*dt*dt*j_m(3,ix_m,iy_m) 
-!      end do
-!    enddo
-!  end if
-      
-      
-  select case(TwoD_shape)
-  case('periodic')
-    Ac_new_m(:,:,0)=Ac_new_m(:,:,NY_m)
-    Ac_new_m(:,:,NY_m+1)=Ac_new_m(:,:,1)
-  case('isolated')
-    Ac_new_m(:,:,0)=Ac_new_m(:,:,1)
-    Ac_new_m(:,:,NY_m+1)=0d0
+  
+  select case(FDTDdim)
+  case('1D')
+    call dt_evolve_Ac_1d()
+  case('2D')
+    call dt_evolve_Ac_2d()
+  case('2DC')
+    call dt_evolve_Ac_2dc()
   end select
-
+  
   call timelog_end(LOG_DT_EVOLVE_AC)
       
   return
 end subroutine dt_evolve_Ac
+!===========================================================
+subroutine calc_elec_field()
+  use Global_variables, only: Ac_old_m, Ac_new_m, Elec, &
+                            & NYvacB_m, NYvacT_m, NXvacL_m, NXvacR_m, &
+                            & dt
+  implicit none
+  integer ix_m,iy_m
+  ! calculate the electric field from the vector potential Ac
+  ! (written by M.Uemoto on 2016-11-22)
+  do iy_m=NYvacB_m, NYvacT_m
+    do ix_m=NXvacL_m, NXvacR_m
+      Elec(:,ix_m,iy_m)=-(Ac_new_m(:,ix_m,iy_m)-Ac_old_m(:,ix_m,iy_m))/(2d0*dt)
+    end do
+  end do
+end subroutine calc_elec_field
+!===========================================================
+subroutine calc_bmag_field_1d()
+  use Global_variables, only: Ac_m, Bmag, NXvacL_m, NXvacR_m, HX_m, c_light
+  implicit none
+  integer :: ix_m
+  real(8) :: Rc(3)  ! rot Ac
+  ! calculate the magnetic field from the vector potential (1D case)
+  ! (written by M.Uemoto on 2016-11-22)
+  do ix_m=NXvacL_m, NXvacR_m
+    Rc(1) = 0.0
+    Rc(2) = - (Ac_m(3,ix_m+1,1) - Ac_m(3,ix_m-1,1)) / (2 * HX_m)
+    Rc(3) = + (Ac_m(2,ix_m+1,1) - Ac_m(2,ix_m-1,1)) / (2 * HX_m)
+    Bmag(:,ix_m,1) = Rc(:) * c_light
+  end do
+  return
+end subroutine calc_bmag_field_1d
+!===========================================================
+subroutine calc_bmag_field_2d()
+  use Global_variables, only: Ac_m, Bmag, &
+                            & NYvacB_m, NYvacT_m, NXvacL_m, NXvacR_m, &
+                            & HX_m, HY_m, c_light
+  implicit none
+  integer :: ix_m,iy_m
+  real(8) :: rc(3)  ! rot Ac
+  ! calculate the magnetic field from the vector potential (2D case)
+  ! (written by M.Uemoto on 2016-11-22)
+  do iy_m=NYvacB_m, NYvacT_m
+    do ix_m=NXvacL_m, NXvacR_m
+      Rc(1) = + (Ac_m(3, ix_m, iy_m+1) - Ac_m(3, ix_m, iy_m-1)) / (2*HY_m)
+      Rc(2) = - (Ac_m(3, ix_m+1, iy_m) - Ac_m(3, ix_m-1, iy_m)) / (2*HX_m)
+      Rc(3) = + (Ac_m(2, ix_m+1, iy_m) - Ac_m(2, ix_m-1, iy_m)) / (2*HX_m) &
+            & - (Ac_m(1, ix_m, iy_m+1) - Ac_m(1, ix_m, iy_m-1)) / (2*HY_m)
+      Bmag(:,ix_m,iy_m) = Rc(:) * c_light
+    end do
+  end do
+  return
+end subroutine calc_bmag_field_2d
+!===========================================================
+subroutine calc_bmag_field_2dc()
+  use Global_variables, only: Ac_m, Bmag, &
+                            & NYvacB_m, NYvacT_m, NXvacL_m, NXvacR_m, &
+                            & HX_m, HY_m, c_light
+  implicit none
+  integer :: ix_m,iy_m
+  real(8) :: Y, Rc(3)  ! rot Ac
+  ! calculate the magnetic field from the vector potential (2D cylindal case)
+  ! (written by M.Uemoto on 2016-11-22)
+  do iy_m=NYvacB_m, NYvacT_m
+    Y = (iy_m-0.5) * HY_m
+    do ix_m=NXvacL_m, NXvacR_m
+      Rc(1) = -0.50*(1.00/HY_m)*Ac_m(3,ix_m+0,iy_m-1) &
+            & +1.00*(1.00/Y)*Ac_m(3,ix_m+0,iy_m+0) &
+            & +0.50*(1.00/HY_m)*Ac_m(3,ix_m+0,iy_m+1)
+      Rc(2) = +0.50*(1.00/HX_m)*Ac_m(3,ix_m-1,iy_m+0) &
+            & -0.50*(1.00/HX_m)*Ac_m(3,ix_m+1,iy_m+0)
+      Rc(3) = +0.50*(1.00/HY_m)*Ac_m(1,ix_m+0,iy_m-1) &
+            & -0.50*(1.00/HY_m)*Ac_m(1,ix_m+0,iy_m+1) &
+            & -0.50*(1.00/HX_m)*Ac_m(2,ix_m-1,iy_m+0) &
+            & +0.50*(1.00/HX_m)*Ac_m(2,ix_m+1,iy_m+0)
+      Bmag(:,ix_m,iy_m) = Rc(:) * c_light
+    end do
+  end do
+  return
+end subroutine calc_bmag_field_2dc
+!===========================================================
+subroutine calc_bmag_field()
+  use Global_variables
+  implicit none
+  select case(FDTDdim)
+  case('1D')
+    call calc_bmag_field_1d()
+  case('2D')
+    call calc_bmag_field_2d()
+  case('2DC')
+    call calc_bmag_field_2dc()
+  end select
+  return
+end subroutine calc_bmag_field
+!===========================================================
+subroutine calc_energy_joule()
+  use Global_variables, only: energy_joule, Elec, j_m, dt, aLxyz, &
+                            & NYvacB_m, NYvacT_m, NXvacL_m, NXvacR_m, pi
+  implicit none
+  integer :: ix_m,iy_m
+  ! calculate the Ohmic losses in the media
+  ! (written by M.Uemoto on 2016-11-22)
+  do iy_m=NYvacB_m,NYvacT_m
+    do ix_m=NXvacL_m,NXvacR_m
+      energy_joule(ix_m, iy_m) = energy_joule(ix_m, iy_m) &
+          & + sum(-j_m(:,ix_m,iy_m) * Elec(:,ix_m,iy_m)) * dt * aLxyz
+    end do
+  end do
+  return
+end subroutine calc_energy_joule
+!===========================================================
+subroutine calc_energy_elemag()
+  use Global_variables, only: Elec, Bmag, energy_elemag, aLxyz, &
+                            & NYvacB_m, NYvacT_m, NXvacL_m, NXvacR_m, pi
+  implicit none
+  integer :: ix_m,iy_m
+  real(8) :: e2, b2
+  ! calculate the total electromagnetic energy
+  ! (written by M.Uemoto on 2016-11-22)
+  do iy_m=NYvacB_m,NYvacT_m
+    do ix_m=NXvacL_m,NXvacR_m
+      e2 = sum(Elec(:, ix_m, iy_m) ** 2)
+      b2 = sum(Bmag(:, ix_m, iy_m) ** 2)
+      energy_elemag(ix_m, iy_m) = (1.0 / (8.0 * pi)) * aLxyz * (e2 + b2)
+    end do
+  end do
+  return
+end subroutine calc_energy_elemag

--- a/FDTD/beam.f90
+++ b/FDTD/beam.f90
@@ -1,0 +1,106 @@
+!
+!  Copyright 2016 ARTED developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+
+!===============================================================
+real(8) function bessel_j1(x)
+  implicit none
+  real(8), intent(in) :: x
+  integer, parameter :: order = 30
+  real(8) :: c, s
+  integer :: m
+
+  c = 0.5 * x
+  s = c
+  do m = 1, 30
+    c = -0.25 * x * x / (m * (m + 1)) * c
+    s = s + c
+  end do
+  bessel_j1 = s
+  return
+end function bessel_j1
+!===============================================================
+real(8) function sin2cos(t, tw, omega, cep)
+  use Global_Variables, only: pi
+  implicit none
+  real(8), intent(in) :: t, tw, omega, cep
+  real(8) :: theta1, theta2
+
+  if ((0 <= t) .and. (t <= tw)) then
+    theta1 = pi / tw * t
+    theta2 = omega * t + 2 * pi * cep
+    sin2cos = sin(theta1) ** 2 * cos(theta2)
+  else
+    sin2cos = 0.0
+  endif
+  return
+end function sin2cos
+!===============================================================
+subroutine incident_bessel_beam()
+  use Global_Variables, only: IWcm2_1, omegaeV_1, tpulsefs_1, Epdir_1, phi_CEP_1, &
+                            & NXvacL_m, NXvacR_m, NYvacB_m, NYvacT_m, &
+                            & HX_m, HY_m, Ac_m, Ac_new_m, dt, &
+                            & pi, c_light
+  implicit none
+  real(8) :: f0_1, omega_1, tpulse_1, wpulse_1
+  integer :: ix_m, iy_m
+  real(8) :: lx, ly, x, y, kx, ky, k, vx
+  real(8) :: f(3), j, tau
+  
+  real(8) bessel_j1, sin2cos
+  
+  ! First pulse
+  f0_1 = 5.338d-9*sqrt(IWcm2_1)  ! electric field in a.u.
+  omega_1 = omegaeV_1 / (2d0*13.6058d0)  ! frequency in a.u.
+  tpulse_1 = tpulsefs_1 / 0.02418d0 ! pulse_duration in a.u.
+  wpulse_1 = 2*pi/tpulse_1
+
+  lx = (NXvacR_m-NXvacL_m) * HX_m
+  ly = NYvacT_m * HY_m
+
+  ky = 3.8317 / ly
+  k = omega_1 / c_light
+  
+  if (ky > k) then
+    call err_finalize('Error: NY,HY is not enough')
+  endif
+  
+  kx = SQRT(k*k-ky*ky)
+  vx = omega_1 / kx
+
+  Ac_m = 0.0
+  Ac_new_m = 0.0
+  do iy_m = NYvacB_m, NYvacT_m
+     y = HY_m * (iy_m - 0.5)
+     j = bessel_j1(ky * y)
+     f = j * f0_1 / 0.58186 * Epdir_1
+     do ix_m = NXvacL_m-1, 0
+       x = ix_m * HX_m
+       ! Ac_new_m
+       tau = - x / vx
+       Ac_new_m(:,ix_m,iy_m) = f * sin2cos(tau, tpulse_1, omega_1, phi_CEP_1)
+       ! Ac_m (previous time-step)
+       tau = - x / vx - dt
+       Ac_m(:,ix_m,iy_m) =  f * sin2cos(tau, tpulse_1, omega_1, phi_CEP_1)
+     end do
+  end do
+  
+  ! impose boundary condition
+  Ac_new_m(:,:,NYvacT_m+1) = 0.0
+  Ac_new_m(:,:,NYvacB_m-1) = Ac_new_m(:,:,NYvacB_m)
+  Ac_m(:,:,NYvacT_m+1) = 0.0
+  Ac_m(:,:,NYvacB_m-1) = Ac_m(:,:,NYvacB_m)
+  return
+end subroutine incident_bessel_beam

--- a/FDTD/beam.f90
+++ b/FDTD/beam.f90
@@ -25,7 +25,7 @@ real(8) function bessel_j1(x)
   c = 0.5 * x
   s = c
   do m = 1, 30
-    c = -0.25 * x * x / (m * (m + 1)) * c
+    c = -0.25d0 * x * x / (m * (m + 1)) * c
     s = s + c
   end do
   bessel_j1 = s
@@ -43,7 +43,7 @@ real(8) function sin2cos(t, tw, omega, cep)
     theta2 = omega * t + 2 * pi * cep
     sin2cos = sin(theta1) ** 2 * cos(theta2)
   else
-    sin2cos = 0.0
+    sin2cos = 0.0d0
   endif
   return
 end function sin2cos
@@ -70,7 +70,7 @@ subroutine incident_bessel_beam()
   lx = (NXvacR_m-NXvacL_m) * HX_m
   ly = NYvacT_m * HY_m
 
-  ky = 3.8317 / ly
+  ky = 3.8317d0 / ly
   k = omega_1 / c_light
   
   if (ky > k) then
@@ -85,7 +85,7 @@ subroutine incident_bessel_beam()
   do iy_m = NYvacB_m, NYvacT_m
      y = HY_m * (iy_m - 0.5)
      j = bessel_j1(ky * y)
-     f = j * f0_1 / 0.58186 * Epdir_1
+     f = j * f0_1 / 0.58186d0 * Epdir_1
      do ix_m = NXvacL_m-1, 0
        x = ix_m * HX_m
        ! Ac_new_m

--- a/main/ms.f90
+++ b/main/ms.f90
@@ -433,16 +433,15 @@ Program main
     call timelog_begin(LOG_OTHER)
 !write section ================================================================================
     if(myrank == 0) then
-      write(941,'(3e26.16E3)')iter*dt,Ac_new_m(2,0,1),Ac_new_m(3,0,1)
+      write(941,'(4e26.16E3)') iter*dt, Ac_new_m(1:3,0,1)
     end if
     if(myrank == 1) then
       ix_m=min(NXvacR_m,NX_m+1)
-      write(942,'(3e26.16E3)')iter*dt,Ac_new_m(2,ix_m,1),Ac_new_m(3,ix_m,1)
+      write(942,'(4e26.16E3)') iter*dt, Ac_new_m(1:3,ix_m,1)
     end if
     if(newrank == 0) then
       ix_m=NX_table(NXY_s)
-      write(943,'(5e26.16E3)')iter*dt,Ac_new_m(2,ix_m,1),Ac_new_m(3,ix_m,1) &
-        &,j_m(2,ix_m,1),j_m(3,ix_m,1)
+      write(943,'(7e26.16E3)') iter*dt, Ac_new_m(1:3,ix_m,1), j_m(1:3,ix_m,1)
     end if
     
     call calc_elec_field()

--- a/modules/global_variables_ms.f90
+++ b/modules/global_variables_ms.f90
@@ -130,6 +130,12 @@ Module Global_Variables
   character(50) :: file_DoS,file_band
   character(50) :: file_dns,file_ovlp,file_nex
   character(50) :: file_kw ! non-uniform k-grid 
+  character(50) :: file_energy_transfer ! 940
+  character(50) :: file_ac_vac          ! 941
+  character(50) :: file_ac_vac_back     ! 942
+  character(50) :: file_ac_m            ! 943
+  character(50) :: file_ac              ! 902
+  
   character(2) :: ext_field
   character(2) :: Longi_Trans
   character(1) :: FSset_option,MD_option
@@ -185,7 +191,7 @@ Module Global_Variables
 
   real(8) :: HX_m,HY_m
   integer :: NX_m,NXvacL_m,NXvacR_m
-  integer :: NY_m
+  integer :: NY_m,NYvacT_m,NYvacB_m
   real(8),allocatable :: Ac_m(:,:,:),Ac_new_m(:,:,:),Ac_old_m(:,:,:)
   real(8),allocatable :: Elec(:,:,:),Bmag(:,:,:)
   real(8),allocatable :: j_m(:,:,:)
@@ -201,6 +207,7 @@ Module Global_Variables
   real(8),allocatable :: Eexc_m(:,:)
   real(8),allocatable :: Vloc_m(:,:)
   real(8),allocatable :: rho_m(:,:)
+  real(8),allocatable :: energy_joule(:,:)
   real(8),allocatable :: energy_elec_Matter_l(:,:)
   real(8),allocatable :: energy_elec_Matter(:,:)
   real(8),allocatable :: energy_elec(:,:)


### PR DESCRIPTION
In this pull request, I have added a new modification which mainly 
provides the electromagnetic calculation mode for the cylindal symmetric 
system, e.g. the propagation, absorption of the cylindal vector beams.

- Add new option of FDTDdim: '2DC' (2D cylindal coordinate)
- Fix the problem of electromagnetic gauge conversion in previous version.
- Modify the output format of 'SYSName_Ac_??????.out' file.
  (add the new column to write out the Acx and Ex components ...etc)
- Add new routine to calculate the matter energy by integrating the Joulle heating.
  (also written in the 'SYSName_Ac_??????.out' file) 
- Fix a bug of the output filename caused by the insufficiency of 
  filename variables when the length SYSName/Directory is too long.