### PR TITLE
Add wrapper module of MPI.

### DIFF
--- a/FDTD/FDTD.f90
+++ b/FDTD/FDTD.f90
@@ -45,14 +45,15 @@ end subroutine write_result
 !===============================================================
 subroutine write_result_all()
   use Global_Variables
+  use communication
   implicit none
   integer :: Ndata, Ndata_per_proc, i, index
   ! export all results by using MPI
   ! (written by M.Uemoto on 2016-11-22)
   Ndata = Nt / Nstep_write
-  Ndata_per_proc = ceiling(float(Ndata) / Nprocs)
+  Ndata_per_proc = ceiling(float(Ndata) / nprocs(1))
   do i=0, Ndata_per_proc-1
-    index = Myrank * Ndata_per_proc + i
+    index = procid(1) * Ndata_per_proc + i
     if (index <= Ndata) then
       call write_result(index)
     endif
@@ -118,6 +119,7 @@ end subroutine write_excited_electron
 !===============================================================
 subroutine init_Ac_ms_2dc()
   use Global_variables
+  use communication
   implicit none
   ! initialization for 2D cylinder mode
   ! (written by M.Uemoto on 2016-11-22)
@@ -129,12 +131,13 @@ subroutine init_Ac_ms_2dc()
   energy_joule=0d0
   call incident_bessel_beam()
   
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  call comm_sync_all
   return
 end subroutine init_Ac_ms_2dc
 !===============================================================
 subroutine init_Ac_ms
   use Global_variables
+  use communication
   implicit none
   real(8) x,y
   integer ix_m,iy_m
@@ -146,8 +149,8 @@ subroutine init_Ac_ms
   real(8) length_y
 
   
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
-  if(myrank == 0)write(*,*)'ok8-1-1'
+  call comm_sync_all
+  if(comm_is_root())write(*,*)'ok8-1-1'
 
 !  BC_my='isolated'
 !  BC_my='periodic'
@@ -179,7 +182,7 @@ subroutine init_Ac_ms
 
 
 
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  call comm_sync_all
 
   select case(FDTDdim)
   case('1D')
@@ -317,8 +320,8 @@ subroutine init_Ac_ms
 
 
   
-  if(Myrank == 0)write(*,*)'ok fdtd 02'
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  if(comm_is_root()) write(*,*)'ok fdtd 02'
+  call comm_sync_all
 
   select case(TwoD_shape)
   case('periodic')

--- a/GS/CG.f90
+++ b/GS/CG.f90
@@ -19,6 +19,7 @@
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 Subroutine CG_omp(iter_cg_max)
   use Global_Variables
+  use communication
   use timelog
   implicit none
   real(8),parameter :: delta_cg=1.d-15
@@ -112,7 +113,7 @@ Subroutine CG_omp(iter_cg_max)
 !$omp end parallel
 
   call timelog_begin(LOG_ALLREDUCE)
-  call MPI_ALLREDUCE(esp_var_l,esp_var,NB*NK,MPI_REAL8,MPI_SUM,NEW_COMM_WORLD,ierr)
+  call comm_summation(esp_var_l,esp_var,NB*NK,proc_group(2))
   call timelog_end(LOG_ALLREDUCE)
 
   call timelog_end(LOG_CG)

--- a/GS/Fermi_Dirac_distribution.f90
+++ b/GS/Fermi_Dirac_distribution.f90
@@ -16,6 +16,7 @@
 Subroutine Fermi_Dirac_distribution
   use Global_Variables
   use communication
+  use timelog
   implicit none
   real(8) :: chemical_potential
   real(8) :: chem_max,chem_min,elec_num
@@ -25,7 +26,7 @@ Subroutine Fermi_Dirac_distribution
   integer :: ik,ib
   real(8) :: timer1,timer2
   
-  timer1=MPI_WTIME()
+  timer1=get_wtime()
   beta_FD=1d0/(KbTev/(2d0*Ry))
   allocate(occ_l(NB,NK),esp_l(NB,NK),esp_temp(NB,NK))
   occ_l=0d0 ; esp_l=0d0
@@ -67,7 +68,7 @@ Subroutine Fermi_Dirac_distribution
   st=sum(occ_l(Nelec/2+1:NB,NK_s:NK_e))
   call comm_summation(st,s,proc_group(2))
 
-  timer2=MPI_WTIME()
+  timer2=get_wtime()
   if(comm_is_root())then
     write(*,*)'Fermi-Dirac dist. time=',timer2-timer1,'sec'
     write(*,*)'chemical potential =',chemical_potential

--- a/GS/Occupation_Redistribution.f90
+++ b/GS/Occupation_Redistribution.f90
@@ -19,6 +19,7 @@
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 Subroutine Occupation_Redistribution
   use Global_Variables
+  use communication, only: comm_is_root
   implicit none
   integer,parameter :: NFSset=100,Nvc_min=1 !Nvc_min:number of primitive cell in our orthorhombic unit cell
   integer :: i,j,k,ib,ik
@@ -27,7 +28,7 @@ Subroutine Occupation_Redistribution
   integer,allocatable :: kv(:),kc(:),bv(:),bc(:)
   real(8),allocatable :: espv(:),espc(:)
 
-  if(Myrank == 0) then
+  if(comm_is_root()) then
     write(*,*) '-----------------------------------------------'
     write(*,*) '-----------------------------------------------'
     write(*,*) 'occupation redistribution is called'
@@ -57,13 +58,13 @@ Subroutine Occupation_Redistribution
       end if
     end do
   end do
-  if(Myrank == 0) then
+  if(comm_is_root()) then
     write(*,*) '# of valence electron above EFermi_min',Nv
     write(*,*) '# of conduction electron below EFermi_max',Nc
   end if
 !When cubic cell contain Nvc_min primitive cell,eigenvalues should be Nvc_min-fold degeneracy.
   if(Nv < Nvc_min .or. Nc < Nvc_min) then
-    if(Myrank == 0) then
+    if(comm_is_root()) then
       write(*,*) '=============================================================='
       write(*,*) 'occupation redistribution is not needed for too small Nv or Nc'
       write(*,*) '=============================================================='
@@ -99,7 +100,7 @@ Subroutine Occupation_Redistribution
     do i=1,Nc
       if (espc(i)<EFermi) Nc_below=Nc_below+nint(wk(kc(i)))
     end do
-    if(Myrank == 0) then
+    if(comm_is_root()) then
       write(*,*)'Nv_above,Nc_below =',Nv_above,Nc_below
     end if
     if(Nv_above==Nc_below) then
@@ -113,7 +114,7 @@ Subroutine Occupation_Redistribution
   call err_finalize('too long calcualtion')
 
 !Changing occupation distribution
-10 if (Myrank==0) write(*,*) 'EFermi =',EFermi
+10 if (comm_is_root()) write(*,*) 'EFermi =',EFermi
   do i=1,Nv
     if (espv(i)>EFermi) then
       NBocc(kv(i))=NBocc(kv(i))-1
@@ -129,7 +130,7 @@ Subroutine Occupation_Redistribution
     occ(NBocc(ik)+1:NB,ik)=0.d0
   end do
   NBoccmax=maxval(NBocc(:))
-  if (Myrank==0) then
+  if (comm_is_root()) then
     if (2*nint(sum(NBocc(:)*wk(:)))/=Nelec*NKxyz) call err_finalize('NBocc(ik) are inconsistent')
     write(*,*) 'NBoccmax became ',NBoccmax
     write(*,*) 'Ne_tot =',sum(occ)

--- a/GS/sp_energy.f90
+++ b/GS/sp_energy.f90
@@ -19,6 +19,7 @@
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 Subroutine sp_energy_omp
   use Global_Variables
+  use communication
   use timelog
   implicit none
   integer :: ik,ib
@@ -54,7 +55,7 @@ Subroutine sp_energy_omp
 !$omp end parallel
 
   call timelog_begin(LOG_ALLREDUCE)
-  CALL MPI_ALLREDUCE(esp_l,esp,NB*NK,MPI_REAL8,MPI_SUM,NEW_COMM_WORLD,ierr)
+  call comm_summation(esp_l,esp,NB*NK,proc_group(2))
   call timelog_end(LOG_ALLREDUCE)
 
   call timelog_end(LOG_SP_ENERGY)

--- a/GS/write_GS_data.f90
+++ b/GS/write_GS_data.f90
@@ -16,10 +16,11 @@
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 Subroutine write_GS_data
   use Global_Variables
+  use communication, only: comm_is_root
   implicit none
   integer ik,ib,ia,iter,j
 
-  if (Myrank == 0) then
+  if (comm_is_root()) then
     open(403,file=file_GS)
     write(403,*) '#---------------------------------------------------------'
     write(403,*) '#grid information-----------------------------------------'

--- a/RT/Fourier_tr.f90
+++ b/RT/Fourier_tr.f90
@@ -16,13 +16,14 @@
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 Subroutine Fourier_tr
   use Global_Variables
+  use communication, only: comm_is_root
   implicit none
   integer :: ihw,ixyz,iter
   real(8) :: hw,tt
   complex(8) :: jav_w(3),E_ext_w(3),E_tot_w(3)
   complex(8) :: zsigma_w(3),zeps(3)
 
-  if (Myrank == 0) then
+  if (comm_is_root()) then
     open(7,file=file_epse)
   endif
 
@@ -45,7 +46,7 @@ Subroutine Fourier_tr
       end if
     end if
       
-    if (Myrank == 0) then
+    if (comm_is_root()) then
       if (ext_field == 'LR' .and. Longi_Trans == 'Lo') then
         write(7,'(1x,f13.7,6f22.14)') hw&
              &,(real(zeps(ixyz)),ixyz=1,3)&
@@ -68,7 +69,7 @@ Subroutine Fourier_tr
     endif
   enddo
  
-  if (Myrank == 0) then
+  if (comm_is_root()) then
     close(7)
   endif
 

--- a/RT/current.f90
+++ b/RT/current.f90
@@ -512,6 +512,7 @@ end subroutine
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 Subroutine current_result_impl(jx,jy,jz)
   use Global_Variables
+  use communication
   use timelog
   implicit none
   real(8),intent(in) :: jx,jy,jz
@@ -523,6 +524,6 @@ Subroutine current_result_impl(jx,jy,jz)
   jav_l(2)=jy
   jav_l(3)=jz
 
-  call MPI_ALLREDUCE(jav_l,jav,3,MPI_REAL8,MPI_SUM,NEW_COMM_WORLD,ierr)
+  call comm_summation(jav_l,jav,3,proc_group(2))
   call timelog_end(LOG_ALLREDUCE)
 end Subroutine

--- a/RT/init_Ac.f90
+++ b/RT/init_Ac.f90
@@ -16,6 +16,7 @@
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 Subroutine init_Ac
   use Global_Variables
+  use communication
   implicit none
   integer :: iter
   real(8) :: tt
@@ -94,14 +95,14 @@ Subroutine init_Ac
       enddo
     case('input')
       Ac_ext=0d0
-      if(Myrank==0)then
+      if(comm_is_root())then
         open(899,file='input_Ac.dat')
         do iter=0,Nt
           read(899,*)Ac_ext(iter,1),Ac_ext(iter,2),Ac_ext(iter,3)
         end do
         close(899)
       end if
-      call MPI_BCAST(Ac_ext,(Nt+3)*3,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
+      call comm_bcast(Ac_ext,proc_group(1))
 
     case('Asin2_cw')
 ! pulse shape : A(t)=f0/omega*sin(Pi t/T)**2 *cos (omega t+phi_CEP*2d0*pi) 

--- a/common/Exc_Cor.f90
+++ b/common/Exc_Cor.f90
@@ -934,6 +934,7 @@ End Subroutine PZMxc
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 Subroutine rho_j_tau(GS_RT,rho_s,tau_s,j_s,grho_s,lrho_s)
   use Global_Variables
+  use communication
   implicit none
   character(2) :: GS_RT
   real(8) :: rho_s(NL),tau_s(NL),j_s(NL,3),grho_s(NL,3),lrho_s(NL)
@@ -1048,8 +1049,8 @@ Subroutine rho_j_tau(GS_RT,rho_s,tau_s,j_s,grho_s,lrho_s)
     end do
   end do
 
-  call MPI_ALLREDUCE(tau_s_l,tau_s,NL,MPI_REAL8,MPI_SUM,NEW_COMM_WORLD,ierr)
-  call MPI_ALLREDUCE(j_s_l,j_s,NL*3,MPI_REAL8,MPI_SUM,NEW_COMM_WORLD,ierr)
+  call comm_summation(tau_s_l,tau_s,NL,proc_group(2))
+  call comm_summation(j_s_l,j_s,NL*3,proc_group(2))
 
   if(flag_nlcc)tau_s = tau_s + 0.5d0*tau_nlcc
 

--- a/common/ion_force.f90
+++ b/common/ion_force.f90
@@ -29,6 +29,7 @@ subroutine Ion_Force_omp(Rion_update,GS_RT)
 contains
   subroutine impl(Rion_update,zutmp,zu_NB)
     use Global_Variables
+    use communication
     use timelog
     implicit none
     character(3),intent(in)  :: Rion_update
@@ -135,7 +136,7 @@ contains
     call timelog_end(LOG_ION_FORCE)
 
     call timelog_begin(LOG_ALLREDUCE)
-    call MPI_ALLREDUCE(ftmp_l,fnl,3*NI,MPI_REAL8,MPI_SUM,NEW_COMM_WORLD,ierr)
+    call comm_summation(ftmp_l,fnl,3*NI,proc_group(2))
     force=Floc+Fnl+Fion
     call timelog_end(LOG_ALLREDUCE)
   end subroutine

--- a/common/psi_rho.f90
+++ b/common/psi_rho.f90
@@ -47,6 +47,7 @@ subroutine psi_rho_impl(zutmp,zu_NB)
   use global_variables
   use timelog
   use opt_variables
+  use communication
 #ifdef ARTED_USE_NVTX
   use nvtx
 #endif
@@ -82,7 +83,7 @@ subroutine psi_rho_impl(zutmp,zu_NB)
   call timelog_end(LOG_PSI_RHO)
 
   call timelog_begin(LOG_ALLREDUCE)
-  call MPI_ALLREDUCE(rho_l,rho,NL,MPI_REAL8,MPI_SUM,NEW_COMM_WORLD,ierr)
+  call comm_summation(rho_l,rho,NL,proc_group(2))
   call timelog_end(LOG_ALLREDUCE)
 
 

--- a/common/total_energy.f90
+++ b/common/total_energy.f90
@@ -16,6 +16,7 @@
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 subroutine Total_Energy_omp(Rion_update,GS_RT)
   use Global_Variables, only: zu,zu_GS,NB,NBoccmax
+  use communication
   implicit none
   character(3),intent(in) :: Rion_update
   character(2),intent(in) :: GS_RT
@@ -170,7 +171,7 @@ contains
     call timelog_begin(LOG_ALLREDUCE)
     !summarize
     if (Rion_update == 'on') then
-      call MPI_ALLREDUCE(Eion_l,Eion_tmp2,1,MPI_REAL8,MPI_SUM,NEW_COMM_WORLD,ierr)
+      call comm_summation(Eion_l,Eion_tmp2,proc_group(2))
       Eion=Eion_tmp1+Eion_tmp2
     end if
 
@@ -179,7 +180,7 @@ contains
     sum_tmp(3) = Enl_l
     sum_tmp(4) = Eloc_l1
     sum_tmp(5) = Eloc_l2
-    call MPI_ALLREDUCE(sum_tmp,sum_result,5,MPI_REAL8,MPI_SUM,NEW_COMM_WORLD,ierr)
+    call comm_summation(sum_tmp,sum_result,5,proc_group(2))
     Ekin = sum_result(1)
     Eh   = sum_result(2)
     Enl  = sum_result(3)

--- a/main/ms.f90
+++ b/main/ms.f90
@@ -25,7 +25,6 @@ Program main
   use environment
   use performance_analyzer
   use communication
-  use misc_routines
   implicit none
   integer :: iter,ik,ib,ia
   character(3) :: Rion_update
@@ -1126,10 +1125,9 @@ End Subroutine Read_data
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 subroutine prep_Reentrance_Read
   use Global_Variables
-  use timelog,       only: timelog_reentrance_read
+  use timelog,       only: timelog_reentrance_read, get_wtime
   use opt_variables, only: opt_vars_initialize_p1, opt_vars_initialize_p2
   use communication
-  use misc_routines
   implicit none
   real(8) :: time_in,time_out
 
@@ -1380,9 +1378,8 @@ end subroutine prep_Reentrance_Read
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 subroutine prep_Reentrance_write
   use Global_Variables
-  use timelog, only: timelog_reentrance_write
+  use timelog, only: timelog_reentrance_write, get_wtime
   use communication
-  use misc_routines
   implicit none
   real(8) :: time_in,time_out
 

--- a/main/ms.f90
+++ b/main/ms.f90
@@ -24,6 +24,8 @@ Program main
   use opt_variables
   use environment
   use performance_analyzer
+  use communication
+  use misc_routines
   implicit none
   integer :: iter,ik,ib,ia
   character(3) :: Rion_update
@@ -32,14 +34,12 @@ Program main
   integer :: index
 !$ integer :: omp_get_max_threads  
 
-  call MPI_init(ierr)
-  call MPI_COMM_SIZE(MPI_COMM_WORLD,Nprocs,ierr)
-  call MPI_COMM_RANK(MPI_COMM_WORLD,Myrank,ierr)
+  call comm_init
 
   call timelog_initialize
   call load_environments
 
-  if(Myrank == 0) then
+  if(comm_is_root(1)) then
     write(*,'(2A)')'ARTED ver. = ',ARTED_ver
     call print_optimize_message
   end if
@@ -47,16 +47,16 @@ Program main
   NUMBER_THREADS=1
 !$  NUMBER_THREADS=omp_get_max_threads()
 !$  if(iter*0 == 0) then
-!$    if(myrank == 0)write(*,*)'parallel = Hybrid'
+!$    if(comm_is_root(1))write(*,*)'parallel = Hybrid'
 !$  else
-  if(myrank == 0)write(*,*)'parallel = Flat MPI'
+  if(comm_is_root(1))write(*,*)'parallel = Flat MPI'
 !$  end if
 
-  if(myrank == 0)write(*,*)'NUMBER_THREADS = ',NUMBER_THREADS
+  if(comm_is_root(1))write(*,*)'NUMBER_THREADS = ',NUMBER_THREADS
 
-  etime1=MPI_WTIME()
-  Time_start=MPI_WTIME() !reentrance
-  call MPI_BCAST(Time_start,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
+  etime1=get_wtime()
+  Time_start=get_wtime() !reentrance
+  call comm_bcast(Time_start,proc_group(1))
   Rion_update='on'
 
   call Read_data
@@ -98,12 +98,12 @@ Program main
   if (MD_option /= 'Y') Rion_update = 'off'
   Eall_GS(0)=Eall
 
-  if(Myrank == 0) write(*,*) 'This is the end of preparation for ground state calculation'
-  if(Myrank == 0) write(*,*) '-----------------------------------------------------------'
+  if(comm_is_root(1)) write(*,*) 'This is the end of preparation for ground state calculation'
+  if(comm_is_root(1)) write(*,*) '-----------------------------------------------------------'
 
   call timelog_reset
   do iter=1,Nscf
-    if (Myrank == 0)  write(*,*) 'iter = ',iter
+    if (comm_is_root(1))  write(*,*) 'iter = ',iter
     if( kbTev < 0d0 )then ! sato
       if (FSset_option == 'Y') then
         if (iter/NFSset_every*NFSset_every == iter .and. iter >= NFSset_start) then
@@ -116,7 +116,7 @@ Program main
           if (minval(esp_cb_min(:))-maxval(esp_vb_max(:))<0.d0) then
             call Occupation_Redistribution
           else
-            if (Myrank == 0) then
+            if (comm_is_root(1)) then
               write(*,*) '======================================='
               write(*,*) 'occupation redistribution is not needed'
               write(*,*) '======================================='
@@ -126,7 +126,7 @@ Program main
       end if
     else if( iter /= 1 )then ! sato
       call Fermi_Dirac_distribution
-      if((Myrank == 0).and.(iter == Nscf))then
+      if((comm_is_root(1)).and.(iter == Nscf))then
         open(126,file='occ.out')
         do ik=1,NK
           do ib=1,NB
@@ -162,7 +162,7 @@ Program main
     esp_var_max(iter)=maxval(esp_var(:,:))
     dns_diff(iter)=sqrt(sum((rho_out(:,iter)-rho_in(:,iter))**2))*Hxyz
 
-    if (Myrank == 0) then
+    if (comm_is_root(1)) then
       write(*,*) 'Total Energy = ',Eall_GS(iter),Eall_GS(iter)-Eall_GS(iter-1)
       write(*,'(a28,3e15.6)') 'jav(1),jav(2),jav(3)= ',jav(1),jav(2),jav(3)
       write(*,'(4(i3,f12.6,2x))') (ib,esp(ib,1),ib=1,NB)
@@ -172,16 +172,16 @@ Program main
       write(*,*) 'var_ave,var_max=',esp_var_ave(iter),esp_var_max(iter)
       write(*,*) 'dns. difference =',dns_diff(iter)
       if (iter/20*20 == iter) then
-         etime2=MPI_WTIME()
+         etime2=get_wtime()
          write(*,*) '====='
          write(*,*) 'elapse time=',etime2-etime1,'sec=',(etime2-etime1)/60,'min'
       end if
       write(*,*) '-----------------------------------------------'
     end if
   end do
-  etime2 = MPI_WTIME()
+  etime2 = get_wtime()
 
-  if(Myrank == 0) then
+  if(comm_is_root(1)) then
     call timelog_set(LOG_DYNAMICS, etime2 - etime1)
     call timelog_show_hour('Ground State time  :', LOG_DYNAMICS)
     call timelog_show_min ('CG time            :', LOG_CG)
@@ -198,7 +198,7 @@ Program main
     call timelog_show_min ('Total_Energy time  :', LOG_TOTAL_ENERGY)
     call timelog_show_min ('Ion_Force time     :', LOG_ION_FORCE)
   end if
-  if(Myrank == 0) write(*,*) 'This is the end of GS calculation'
+  if(comm_is_root(1)) write(*,*) 'This is the end of GS calculation'
 
   zu_GS0(:,:,:)=zu_GS(:,:,:)
 
@@ -216,17 +216,17 @@ Program main
   Vloc_GS(:)=Vloc(:)
   call Total_Energy_omp(Rion_update,'GS')
   Eall0=Eall
-  if(Myrank == 0) write(*,*) 'Eall =',Eall
+  if(comm_is_root(1)) write(*,*) 'Eall =',Eall
 
-  etime2=MPI_WTIME()
-  if (Myrank == 0) then
+  etime2=get_wtime()
+  if (comm_is_root(1)) then
     write(*,*) '-----------------------------------------------'
     write(*,*) 'static time=',etime2-etime1,'sec=', (etime2-etime1)/60,'min'
     write(*,*) '-----------------------------------------------'
   end if
   etime1=etime2
 
-  if (Myrank == 0) then
+  if (comm_is_root(1)) then
     write(*,*) '-----------------------------------------------'
     write(*,*) '----some information for Band map--------------'
     do ik=1,NK 
@@ -257,7 +257,7 @@ Program main
   call opt_vars_init_t4ppt()
 #endif
 
-  if(Myrank == 0) write(*,*) 'This is the end of preparation for Real time calculation'
+  if(comm_is_root(1)) write(*,*) 'This is the end of preparation for Real time calculation'
 
 !====RT calculation============================
 
@@ -297,7 +297,7 @@ Program main
   write(file_ac_vac_back, "(A,'Ac_Vac_back.out')") trim(directory)
   write(file_ac_m, "(A,'Ac_M',I4.4,'.out')") trim(directory), NXY_s
   
-  if (Myrank == 0) then
+  if (comm_is_root(1)) then
 !    open(7,file=file_epst,position = position_option)
 !    open(8,file=file_dns,position = position_option)
 !    open(9,file=file_force_dR,position = position_option)
@@ -308,15 +308,15 @@ Program main
 !      open(408,file=file_nex,position = position_option) 
 !    end if
   endif
-  if (Myrank == 1) then
+  if (procid(1) == ROOT_PROCID+1) then
     open(942,file=file_ac_vac_back, position = position_option)
   end if
 
-  if(Newrank == 0)then
+  if(comm_is_root(2))then
     open(943,file=file_ac_m ,position = position_option)
   end if
 
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  call comm_sync_all
 
 !$acc enter data copyin(ik_table,ib_table)
 !$acc enter data copyin(lapx,lapy,lapz)
@@ -329,7 +329,7 @@ Program main
 
   call timelog_reset
   call timelog_enable_verbose
-  etime1=MPI_WTIME()
+  etime1=get_wtime()
 !$acc enter data copyin(zu)
   RTiteratopm : do iter=entrance_iter+1,Nt ! sato
 
@@ -380,7 +380,7 @@ Program main
         jav(1)=0d0
         jav(2)=0d0
       end if
-      if(NEWRANK == 0)then
+      if(comm_is_root(2))then
         jmatter_m_l(1:3,ix_m,iy_m)=jav(1:3)
       end if
 ! sato ---------------------------------------
@@ -402,7 +402,7 @@ Program main
       end if
     
       call timelog_begin(LOG_OTHER)
-      if(NEWRANK == 0)then ! sato
+      if(comm_is_root(2))then ! sato
         energy_elec_Matter_l(ix_m,iy_m)=Eall-Eall0 ! sato
       end if ! sato
       call timelog_end(LOG_OTHER)
@@ -411,12 +411,12 @@ Program main
 !Adiabatic evolution
       if (AD_RHO /= 'No' .and. mod(iter,100) == 0) then
         call k_shift_wf(Rion_update,2)
-        if(NEWRANK == 0)then ! sato
+        if(comm_is_root(2))then ! sato
           excited_electron_l(ix_m,iy_m)=sum(occ)-sum(ovlp_occ(1:NBoccmax,:))
         end if ! sato
       else if (iter == Nt ) then
         call k_shift_wf(Rion_update,2)
-        if(NEWRANK == 0)then ! sato
+        if(comm_is_root(2))then ! sato
           excited_electron_l(ix_m,iy_m)=sum(occ)-sum(ovlp_occ(1:NBoccmax,:))
         end if ! sato
       end if
@@ -425,23 +425,23 @@ Program main
     end do Macro_loop
 
     call timelog_begin(LOG_ALLREDUCE)
-    call MPI_ALLREDUCE(jmatter_m_l,jmatter_m,3*NX_m*NY_m,MPI_REAL8,MPI_SUM,MPI_COMM_WORLD,ierr)
+    call comm_summation(jmatter_m_l,jmatter_m,3*NX_m*NY_m,proc_group(1))
     j_m(:,1:NX_m,1:NY_m)=jmatter_m(:,1:NX_m,1:NY_m)
     if(mod(iter,10) == 1) then
-      call MPI_BCAST(reentrance_switch,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
+      call comm_bcast(reentrance_switch,proc_group(1))
     end if
     call timelog_end(LOG_ALLREDUCE)
 
     call timelog_begin(LOG_OTHER)
 !write section ================================================================================
-    if(myrank == 0) then
+    if(comm_is_root(1)) then
       write(941,'(4e26.16E3)') iter*dt, Ac_new_m(1:3,0,1)
     end if
-    if(myrank == 1) then
+    if(procid(1) == ROOT_PROCID+1) then
       ix_m=min(NXvacR_m,NX_m+1)
       write(942,'(4e26.16E3)') iter*dt, Ac_new_m(1:3,ix_m,1)
     end if
-    if(newrank == 0) then
+    if(comm_is_root(2)) then
       ix_m=NX_table(NXY_s)
       write(943,'(7e26.16E3)') iter*dt, Ac_new_m(1:3,ix_m,1), j_m(1:3,ix_m,1)
     end if
@@ -457,8 +457,7 @@ Program main
       call timelog_end(LOG_OTHER)
       
       call timelog_begin(LOG_ALLREDUCE)
-      call MPI_ALLREDUCE(energy_elec_Matter_l,energy_elec_Matter &
-        &,NX_m*NY_m,MPI_REAL8,MPI_SUM,MPI_COMM_WORLD,ierr)
+      call comm_summation(energy_elec_Matter_l,energy_elec_Matter,NX_m*NY_m,proc_group(1))
       call timelog_end(LOG_ALLREDUCE)
 
       call timelog_begin(LOG_OTHER)
@@ -483,7 +482,7 @@ Program main
       data_out(15,NXvacL_m:NXvacR_m,NYvacB_m:NYvacT_m,index)=energy_elec(NXvacL_m:NXvacR_m,NYvacB_m:NYvacT_m)
       data_out(16,NXvacL_m:NXvacR_m,NYvacB_m:NYvacT_m,index)=energy_total(NXvacL_m:NXvacR_m,NYvacB_m:NYvacT_m)
 
-      if(MYrank == 0)then
+      if(comm_is_root(1))then
         call write_result(index)
 !        write(940,'(4e26.16E3)')iter*dt,sum(energy_elec)*HX_m*HY_m/aLxyz &
 !          &,sum(energy_elemag)*HX_m*HY_m/aLxyz,sum(energy_total)*HX_m*HY_m/aLxyz
@@ -493,22 +492,20 @@ Program main
 
     if (AD_RHO /= 'No' .and. mod(iter,100) == 0 ) then 
       call timelog_begin(LOG_ALLREDUCE)
-      call MPI_ALLREDUCE(excited_electron_l,excited_electron &
-        &,NX_m*NY_m,MPI_REAL8,MPI_SUM,MPI_COMM_WORLD,ierr)
+      call comm_summation(excited_electron_l,excited_electron,NX_m*NY_m,proc_group(1))
       call timelog_end(LOG_ALLREDUCE)
-      if(myrank == 0)call write_excited_electron(iter)
+      if(comm_is_root(1))call write_excited_electron(iter)
     else if (iter == Nt ) then
       call timelog_begin(LOG_ALLREDUCE)
-      call MPI_ALLREDUCE(excited_electron_l,excited_electron &
-        &,NX_m*NY_m,MPI_REAL8,MPI_SUM,MPI_COMM_WORLD,ierr)
+      call comm_summation(excited_electron_l,excited_electron,NX_m*NY_m,proc_group(1))
       call timelog_end(LOG_ALLREDUCE)
-      if(myrank == 0)call write_excited_electron(iter)
+      if(comm_is_root(1))call write_excited_electron(iter)
     end if
 
     call timelog_begin(LOG_OTHER)
     if (reentrance_switch == 1) then 
-      call MPI_BARRIER(MPI_COMM_WORLD,ierr)
-      write(*,*) Myrank,'iter =',iter
+      call comm_sync_all
+      write(*,*) procid(1),'iter =',iter
       iter_now=iter
 !$acc update self(zu)
       call prep_Reentrance_write
@@ -516,17 +513,17 @@ Program main
     end if
 
 !Timer
-    etime2=MPI_WTIME()
+    etime2=get_wtime()
     call timelog_set(LOG_DYNAMICS, etime2 - etime1)
-    if (iter/1000*1000 == iter.and.Myrank == 0) then
+    if (iter/1000*1000 == iter.and.comm_is_root(1)) then
       write(*,*) 'iter =',iter
       call timelog_show_hour('dynamics time     :', LOG_DYNAMICS)
     end if
 
 !Timer for shutdown
     if (mod(iter,10) == 0) then
-      Time_now=MPI_WTIME()
-      if (Myrank == 0 .and. iter/100*100 == iter) then
+      Time_now=get_wtime()
+      if (comm_is_root(1) .and. iter/100*100 == iter) then
         write(*,*) 'Total time =',(Time_now-Time_start)
       end if
       if ((Time_now - Time_start)>Time_shutdown) then 
@@ -538,11 +535,11 @@ Program main
 
   enddo RTiteratopm !end of RT iteraction========================
 !$acc exit data copyout(zu)
-  etime2=MPI_WTIME()
+  etime2=get_wtime()
   call timelog_set(LOG_DYNAMICS, etime2 - etime1)
   call timelog_disable_verbose
 
-  if(Myrank == 0) then
+  if(comm_is_root(1)) then
     call timelog_show_hour('dynamics time      :', LOG_DYNAMICS)
     call timelog_show_min ('dt_evolve_Ac time  :', LOG_DT_EVOLVE_AC)
     call timelog_show_min ('dt_evolve time     :', LOG_DT_EVOLVE)
@@ -562,24 +559,24 @@ Program main
   end if
   call write_performance(trim(directory)//'ms_performance')
 
-  if(Myrank == 0) write(*,*) 'This is the start of write section'
-  etime1=MPI_WTIME()
+  if(comm_is_root(1)) write(*,*) 'This is the start of write section'
+  etime1=get_wtime()
   call write_result_all
-  etime2=MPI_WTIME()
-  if(Myrank == 0) write(*,*) 'This is the end of write section'
-  if(Myrank == 0) write(*,*) 'write time =',etime2-etime1,'sec'
+  etime2=get_wtime()
+  if(comm_is_root(1)) write(*,*) 'This is the end of write section'
+  if(comm_is_root(1)) write(*,*) 'write time =',etime2-etime1,'sec'
 
-  if(Myrank == 0) write(*,*) 'This is the end of RT calculation'
+  if(comm_is_root(1)) write(*,*) 'This is the end of RT calculation'
 
 !====RT calculation===========================
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  call comm_sync_all
 
-  if (Myrank == 0) write(*,*) 'This is the end of all calculation'
-  Time_now=MPI_WTIME()
-  if (Myrank == 0 ) write(*,*) 'Total time =',(Time_now-Time_start)
+  if (comm_is_root(1)) write(*,*) 'This is the end of all calculation'
+  Time_now=get_wtime()
+  if (comm_is_root(1) ) write(*,*) 'Total time =',(Time_now-Time_start)
 
-1 if(Myrank == 0) write(*,*)  'This calculation is shutdown successfully!'
-  if(Myrank == 0) then
+1 if(comm_is_root(1)) write(*,*)  'This calculation is shutdown successfully!'
+  if(comm_is_root(1)) then
     close(940)
     close(941)
 !    close(7)
@@ -590,13 +587,13 @@ Program main
 !      close(408)                                                      
 !    end if
   endif
-  if(Myrank == 1) then
+  if(procid(1) == ROOT_PROCID+1) then
     close(942)
   end if
-  if(Newrank == 0) then
+  if(comm_is_root(2)) then
     close(943)
   end if
-  call MPI_FINALIZE(ierr)
+  call comm_finalize
 
 End Program Main
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
@@ -604,13 +601,14 @@ Subroutine Read_data
   use Global_Variables
   use opt_variables
   use environment
+  use communication
   implicit none
   integer :: ia,i,j
   integer :: ix_m,iy_m
 
-  if (Myrank == 0) then
-    write(*,*) 'Nprocs=',Nprocs
-    write(*,*) 'Myrank=0:  ',Myrank
+  if (comm_is_root()) then
+    write(*,*) 'Nprocs=',nprocs(1)
+    write(*,*) 'procid(1)=0:  ',procid(1)
 
     read(*,*) entrance_option
     write(*,*) 'entrance_option=',entrance_option
@@ -619,8 +617,8 @@ Subroutine Read_data
 
   end if
 
-  call MPI_BCAST(entrance_option,10,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Time_shutdown,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
+  call comm_bcast(entrance_option,proc_group(1))
+  call comm_bcast(Time_shutdown,proc_group(1))
 
   if(entrance_option == 'reentrance') then
     call err_finalize('Re-entrance function does not work now!')
@@ -632,7 +630,7 @@ Subroutine Read_data
   end if
 
 
-  if(Myrank == 0)then
+  if(comm_is_root())then
     read(*,*) entrance_iter
     read(*,*) SYSname
     read(*,*) directory
@@ -691,68 +689,68 @@ Subroutine Read_data
     write(*,*) 'KbTev=',KbTev ! sato
   end if
 
-  call MPI_BCAST(SYSname,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(directory,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
+  call comm_bcast(SYSname,proc_group(1))
+  call comm_bcast(directory,proc_group(1))
 !yabana
-  call MPI_BCAST(functional,10,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(cval,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
+  call comm_bcast(functional,proc_group(1))
+  call comm_bcast(cval,proc_group(1))
 !yabana
 
-  call MPI_BCAST(ps_format,10,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)!shinohara
-  call MPI_BCAST(PSmask_option,1,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)!shinohara
-  call MPI_BCAST(alpha_mask,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr) !shinohara
-  call MPI_BCAST(gamma_mask,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr) !shinohara
-  call MPI_BCAST(eta_mask,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr) !shinohara
+  call comm_bcast(ps_format,proc_group(1))!shinohara
+  call comm_bcast(PSmask_option,proc_group(1))!shinohara
+  call comm_bcast(alpha_mask,proc_group(1)) !shinohara
+  call comm_bcast(gamma_mask,proc_group(1)) !shinohara
+  call comm_bcast(eta_mask,proc_group(1)) !shinohara
 
-  call MPI_BCAST(file_GS,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(file_RT,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(file_epst,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(file_epse,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(file_force_dR,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(file_j_ac,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)  
-  call MPI_BCAST(file_DoS,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(file_band,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(file_dns,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(file_ovlp,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(file_nex,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(file_kw,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(aL,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(ax,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(ay,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(az,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Sym,1,MPI_Integer,0,MPI_COMM_WORLD,ierr) !sym
-  call MPI_BCAST(crystal_structure,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Nd,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(NLx,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(NLy,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(NLz,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(NKx,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(NKy,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(NKz,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(FDTDdim,20,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr) ! sato
-  call MPI_BCAST(TwoD_shape,20,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr) ! sato
-  call MPI_BCAST(NX_m,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr) ! sato
-  call MPI_BCAST(NY_m,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr) ! sato
-  call MPI_BCAST(HX_m,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr) ! sato
-  call MPI_BCAST(HY_m,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr) ! sato
-  call MPI_BCAST(NKsplit,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr) ! sato
-  call MPI_BCAST(NXYsplit,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr) ! sato
-  call MPI_BCAST(NXvacL_m,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr) ! sato
-  call MPI_BCAST(NXvacR_m,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr) ! sato
-  call MPI_BCAST(NEwald,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(aEwald,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(KbTev,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr) ! sato
+  call comm_bcast(file_GS,proc_group(1))
+  call comm_bcast(file_RT,proc_group(1))
+  call comm_bcast(file_epst,proc_group(1))
+  call comm_bcast(file_epse,proc_group(1))
+  call comm_bcast(file_force_dR,proc_group(1))
+  call comm_bcast(file_j_ac,proc_group(1))  
+  call comm_bcast(file_DoS,proc_group(1))
+  call comm_bcast(file_band,proc_group(1))
+  call comm_bcast(file_dns,proc_group(1))
+  call comm_bcast(file_ovlp,proc_group(1))
+  call comm_bcast(file_nex,proc_group(1))
+  call comm_bcast(file_kw,proc_group(1))
+  call comm_bcast(aL,proc_group(1))
+  call comm_bcast(ax,proc_group(1))
+  call comm_bcast(ay,proc_group(1))
+  call comm_bcast(az,proc_group(1))
+  call comm_bcast(Sym,proc_group(1)) !sym
+  call comm_bcast(crystal_structure,proc_group(1))
+  call comm_bcast(Nd,proc_group(1))
+  call comm_bcast(NLx,proc_group(1))
+  call comm_bcast(NLy,proc_group(1))
+  call comm_bcast(NLz,proc_group(1))
+  call comm_bcast(NKx,proc_group(1))
+  call comm_bcast(NKy,proc_group(1))
+  call comm_bcast(NKz,proc_group(1))
+  call comm_bcast(FDTDdim,proc_group(1)) ! sato
+  call comm_bcast(TwoD_shape,proc_group(1)) ! sato
+  call comm_bcast(NX_m,proc_group(1)) ! sato
+  call comm_bcast(NY_m,proc_group(1)) ! sato
+  call comm_bcast(HX_m,proc_group(1)) ! sato
+  call comm_bcast(HY_m,proc_group(1)) ! sato
+  call comm_bcast(NKsplit,proc_group(1)) ! sato
+  call comm_bcast(NXYsplit,proc_group(1)) ! sato
+  call comm_bcast(NXvacL_m,proc_group(1)) ! sato
+  call comm_bcast(NXvacR_m,proc_group(1)) ! sato
+  call comm_bcast(NEwald,proc_group(1))
+  call comm_bcast(aEwald,proc_group(1))
+  call comm_bcast(KbTev,proc_group(1)) ! sato
 
   if(FDTDdim == '1D' .and. TwoD_shape /= 'periodic') then
-     if(Myrank == 0)write(*,*)'Warning !! 1D calculation ! TwoD_shape is not good'
+     if(comm_is_root())write(*,*)'Warning !! 1D calculation ! TwoD_shape is not good'
      TwoD_shape='periodic'
   end if
   if(FDTDdim == '1D' .and. NY_m /= 1) then
-     if(Myrank == 0)write(*,*)'Warning !! 1D calculation ! NY_m is not good'
+     if(comm_is_root())write(*,*)'Warning !! 1D calculation ! NY_m is not good'
      NY_m=1
   end if
   if(FDTDdim == '2D' .and. TwoD_shape /= 'periodic') then
-     if(Myrank == 0)write(*,*)'Warning !! 2D calculation ! TwoD_shape is not good'
+     if(comm_is_root())write(*,*)'Warning !! 2D calculation ! TwoD_shape is not good'
      TwoD_shape='periodic'
   end if
 
@@ -801,7 +799,7 @@ Subroutine Read_data
   if(mod(NKx,2)+mod(NKy,2)+mod(NKz,2) /= 0) call err_finalize('NKx,NKy,NKz /= even')
   if(mod(NLx,2)+mod(NLy,2)+mod(NLz,2) /= 0) call err_finalize('NLx,NLy,NLz /= even')
 
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  call comm_sync_all
 
   aLx=ax*aL;    aLy=ay*aL;    aLz=az*aL
   aLxyz=aLx*aLy*aLz
@@ -822,7 +820,7 @@ Subroutine Read_data
       NK=NKz*(NKx/2)*((NKx/2)+1)/2
     end select
   else
-    if (myrank == 0) then
+    if (comm_is_root()) then
       write(*,*) "Use non-uniform k-points distribution"
       write(*,*) "file_kw=", file_kw
       open(410, file=file_kw, status="old")
@@ -830,16 +828,16 @@ Subroutine Read_data
       close(410)
       write(*,*) "NK=", NK, "NKxyz=", NKxyz
     endif
-    call MPI_BCAST(NK,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-    call MPI_BCAST(NKxyz,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
+    call comm_bcast(NK,proc_group(1))
+    call comm_bcast(NKxyz,proc_group(1))
   endif
 
 ! sato ---------------------------------------------------------------------------------------
   if(NXYsplit /= 1 .and. NKsplit /=1) call err_finalize('cannot respond your request')
-  if(NX_m*NY_m*NKsplit/NXYsplit /= NProcs) call err_finalize('NProcs is not good')
+  if(NX_m*NY_m*NKsplit/NXYsplit /= nprocs(1)) call err_finalize('NProcs is not good')
 
-  NXY_s=NXYsplit*Myrank/NKsplit
-  NXY_e=(NXYsplit*(Myrank+1)-1)/NKsplit 
+  NXY_s=NXYsplit*procid(1)/NKsplit
+  NXY_e=(NXYsplit*(procid(1)+1)-1)/NKsplit
 
   allocate(NX_table(0:NX_m*NY_m-1),NY_table(0:NX_m*NY_m-1))
   i=-1
@@ -852,49 +850,47 @@ Subroutine Read_data
   end do
 
   macRANK=NXY_s
-  kRANK=mod(Myrank,NKsplit)
+  kRANK=mod(procid(1),NKsplit)
 
-  call MPI_COMM_SPLIT(MPI_COMM_WORLD,macRANK,kRANK,NEW_COMM_WORLD,ierr)
-  call MPI_COMM_SIZE(NEW_COMM_WORLD,NEWprocs,ierr)
-  call MPI_COMM_RANK(NEW_COMM_WORLD,NEWrank,ierr)
+  call comm_set_level2_group(macRANK, kRANK)
 
 !  NK_ave=NK/Nprocs; NK_remainder=NK-NK_ave*Nprocs
 !  NG_ave=NG/Nprocs; NG_remainder=NG-NG_ave*Nprocs
 
-  NK_ave=NK/NEWprocs; NK_remainder=NK-NK_ave*NEWprocs
-  NG_ave=NG/NEWprocs; NG_remainder=NG-NG_ave*NEWprocs
+  NK_ave=NK/nprocs(2); NK_remainder=NK-NK_ave*nprocs(2)
+  NG_ave=NG/nprocs(2); NG_remainder=NG-NG_ave*nprocs(2)
 
   if(is_symmetric_mode() == 1 .and. ENABLE_LOAD_BALANCER == 1) then
-    call symmetric_load_balancing(NK,NK_ave,NK_s,NK_e,NK_remainder,NEWrank,NEWprocs)
+    call symmetric_load_balancing(NK,NK_ave,NK_s,NK_e,NK_remainder,procid(2),nprocs(2))
   else
-    if (NK/NEWprocs*NEWprocs == NK) then
-      NK_s=NK_ave*NEWrank+1
-      NK_e=NK_ave*(NEWrank+1)
+    if (NK/nprocs(2)*nprocs(2) == NK) then
+      NK_s=NK_ave*procid(2)+1
+      NK_e=NK_ave*(procid(2)+1)
     else
-      if (NEWrank < (NEWprocs-1) - NK_remainder + 1) then
-        NK_s=NK_ave*NEWrank+1
-        NK_e=NK_ave*(NEWrank+1)
+      if (procid(2) < (nprocs(2)-1) - NK_remainder + 1) then
+        NK_s=NK_ave*procid(2)+1
+        NK_e=NK_ave*(procid(2)+1)
       else
-        NK_s=NK-(NK_ave+1)*((NEWprocs-1)-NEWrank)-NK_ave
-        NK_e=NK-(NK_ave+1)*((NEWprocs-1)-NEWrank)
+        NK_s=NK-(NK_ave+1)*((nprocs(2)-1)-procid(2))-NK_ave
+        NK_e=NK-(NK_ave+1)*((nprocs(2)-1)-procid(2))
       end if
     end if
-    if(NEWrank == NEWprocs-1 .and. NK_e /= NK) call err_finalize('prep. NK_e error')
+    if(procid(2) == nprocs(2)-1 .and. NK_e /= NK) call err_finalize('prep. NK_e error')
   endif
 
-  if (NG/NEWprocs*NEWprocs == NG) then
-    NG_s=NG_ave*NEWrank+1
-    NG_e=NG_ave*(NEWrank+1)
+  if (NG/nprocs(2)*nprocs(2) == NG) then
+    NG_s=NG_ave*procid(2)+1
+    NG_e=NG_ave*(procid(2)+1)
   else
-    if (NEWrank < (NEWprocs-1) - NG_remainder + 1) then
-      NG_s=NG_ave*NEWrank+1
-      NG_e=NG_ave*(NEWrank+1)
+    if (procid(2) < (nprocs(2)-1) - NG_remainder + 1) then
+      NG_s=NG_ave*procid(2)+1
+      NG_e=NG_ave*(procid(2)+1)
     else
-      NG_s=NG-(NG_ave+1)*((NEWprocs-1)-NEWrank)-NG_ave
-      NG_e=NG-(NG_ave+1)*((NEWprocs-1)-NEWrank) 
+      NG_s=NG-(NG_ave+1)*((nprocs(2)-1)-procid(2))-NG_ave
+      NG_e=NG-(NG_ave+1)*((nprocs(2)-1)-procid(2))
     end if
   end if
-  if(NEWrank == NEWprocs-1 .and. NG_e /= NG) call err_finalize('prep. NG_e error')
+  if(procid(2) == nprocs(2)-1 .and. NG_e /= NG) call err_finalize('prep. NG_e error')
 ! sato ---------------------------------------------------------------------------------------
 
   allocate(lap(-Nd:Nd),nab(-Nd:Nd))
@@ -931,7 +927,7 @@ Subroutine Read_data
   allocate(itable_sym(Sym,NL)) ! sym
   allocate(rho_l(NL),rho_tmp1(NL),rho_tmp2(NL)) !sym
 
-  if (Myrank == 0) then
+  if (comm_is_root()) then
     read(*,*) NB,Nelec
     write(*,*) 'NB,Nelec=',NB,Nelec
   endif
@@ -942,10 +938,10 @@ Subroutine Read_data
   end if
 
 
-  call MPI_BCAST(Nelec,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr) ! sato
-  call MPI_BCAST(NB,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(NBoccmax,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  call comm_bcast(Nelec,proc_group(1)) ! sato
+  call comm_bcast(NB,proc_group(1))
+  call comm_bcast(NBoccmax,proc_group(1))
+  call comm_sync_all
   NKB=(NK_e-NK_s+1)*NBoccmax ! sato
 
   allocate(occ(NB,NK),wk(NK),esp(NB,NK))
@@ -958,7 +954,7 @@ Subroutine Read_data
   NBocc(:)=NBoccmax
   allocate(esp_vb_min(NK),esp_vb_max(NK)) !redistribution
   allocate(esp_cb_min(NK),esp_cb_max(NK)) !redistribution
-  if (Myrank == 0) then
+  if (comm_is_root()) then
     read(*,*) FSset_option
     read(*,*) Ncg
     read(*,*) Nmemory_MB,alpha_MB
@@ -982,28 +978,28 @@ Subroutine Read_data
     write(*,*) 'AD_RHO =', AD_RHO
     write(*,*) 'Nt,dt=',Nt,dt
   endif
-  call MPI_BCAST(FSset_option,1,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Ncg,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Nmemory_MB,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(alpha_MB,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(NFSset_start,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(NFSset_every,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Nscf,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-!  call MPI_BCAST(ext_field,2,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Longi_Trans,2,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(MD_option,1,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(AD_RHO,2,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Nt,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(dt,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(entrance_option,12,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-!  call MPI_BCAST(Time_shutdown,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(entrance_iter,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  call comm_bcast(FSset_option,proc_group(1))
+  call comm_bcast(Ncg,proc_group(1))
+  call comm_bcast(Nmemory_MB,proc_group(1))
+  call comm_bcast(alpha_MB,proc_group(1))
+  call comm_bcast(NFSset_start,proc_group(1))
+  call comm_bcast(NFSset_every,proc_group(1))
+  call comm_bcast(Nscf,proc_group(1))
+!  call comm_bcast(ext_field,proc_group(1))
+  call comm_bcast(Longi_Trans,proc_group(1))
+  call comm_bcast(MD_option,proc_group(1))
+  call comm_bcast(AD_RHO,proc_group(1))
+  call comm_bcast(Nt,proc_group(1))
+  call comm_bcast(dt,proc_group(1))
+  call comm_bcast(entrance_option,proc_group(1))
+!  call comm_bcast(Time_shutdown,proc_group(1))
+  call comm_bcast(entrance_iter,proc_group(1))
+  call comm_sync_all
 !  if(ext_field /= 'LF' .and. ext_field /= 'LR' ) call err_finalize('incorrect option for ext_field')
 !  if(Longi_Trans /= 'Lo' .and. Longi_Trans /= 'Tr' ) call err_finalize('incorrect option for Longi_Trans')
   if(AD_RHO /= 'TD' .and. AD_RHO /= 'GS' .and. AD_RHO /= 'No' ) call err_finalize('incorrect option for Longi_Trans')
 
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  call comm_sync_all
 
   allocate(javt(0:Nt,3))
   allocate(Ac_ext(-1:Nt+1,3),Ac_ind(-1:Nt+1,3),Ac_tot(-1:Nt+1,3))
@@ -1043,7 +1039,7 @@ Subroutine Read_data
     allocate(data_out(16,NXvacL_m:NXvacR_m,NY_m+1,0:Nt/Nstep_write))
 ! sato ---------------------------------------------------------------------------------------
 
-  if (Myrank == 0) then
+  if (comm_is_root()) then
     read(*,*) dAc
     read(*,*) Nomega,domega
     read(*,*) AE_shape
@@ -1066,24 +1062,24 @@ Subroutine Read_data
     write(*,*) '===========ion configuration================'
     write(*,*) 'NI,NE=',NI,NE
   endif
-  call MPI_BCAST(dAc,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Nomega,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(domega,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(AE_shape,8,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(IWcm2_1,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(tpulsefs_1,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(omegaev_1,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(phi_CEP_1,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Epdir_1,3,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(IWcm2_2,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(tpulsefs_2,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(omegaev_2,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(phi_CEP_2,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Epdir_2,3,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(T1_T2fs,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(NI,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(NE,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  call comm_bcast(dAc,proc_group(1))
+  call comm_bcast(Nomega,proc_group(1))
+  call comm_bcast(domega,proc_group(1))
+  call comm_bcast(AE_shape,proc_group(1))
+  call comm_bcast(IWcm2_1,proc_group(1))
+  call comm_bcast(tpulsefs_1,proc_group(1))
+  call comm_bcast(omegaev_1,proc_group(1))
+  call comm_bcast(phi_CEP_1,proc_group(1))
+  call comm_bcast(Epdir_1,proc_group(1))
+  call comm_bcast(IWcm2_2,proc_group(1))
+  call comm_bcast(tpulsefs_2,proc_group(1))
+  call comm_bcast(omegaev_2,proc_group(1))
+  call comm_bcast(phi_CEP_2,proc_group(1))
+  call comm_bcast(Epdir_2,proc_group(1))
+  call comm_bcast(T1_T2fs,proc_group(1))
+  call comm_bcast(NI,proc_group(1))
+  call comm_bcast(NE,proc_group(1))
+  call comm_sync_all
   if(AE_shape /= 'Asin2cos' .and. AE_shape /= 'Esin2sin' &
     &.and. AE_shape /= 'input' .and. AE_shape /= 'Asin2_cw' ) call err_finalize('incorrect option for AE_shape')
 
@@ -1099,7 +1095,7 @@ Subroutine Read_data
   allocate(udVtbl(Nrmax,0:Lmax,NE),dudVtbl(Nrmax,0:Lmax,NE))
   allocate(Floc(3,NI),Fnl(3,NI),Fion(3,NI))                         
 
-  if (Myrank == 0) then
+  if (comm_is_root()) then
     read(*,*) (Zatom(j),j=1,NE)
     read(*,*) (Lref(j),j=1,NE)
     do ia=1,NI
@@ -1115,11 +1111,11 @@ Subroutine Read_data
     end do
   endif
 
-  call MPI_BCAST(Zatom,NE,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Kion,NI,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Lref,NE,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Rion,3*NI,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  call comm_bcast(Zatom,proc_group(1))
+  call comm_bcast(Kion,proc_group(1))
+  call comm_bcast(Lref,proc_group(1))
+  call comm_bcast(Rion,proc_group(1))
+  call comm_sync_all
 
   Rion(1,:)=Rion(1,:)*aLx
   Rion(2,:)=Rion(2,:)*aLy
@@ -1132,18 +1128,20 @@ subroutine prep_Reentrance_Read
   use Global_Variables
   use timelog,       only: timelog_reentrance_read
   use opt_variables, only: opt_vars_initialize_p1, opt_vars_initialize_p2
+  use communication
+  use misc_routines
   implicit none
   real(8) :: time_in,time_out
 
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
-  time_in=MPI_WTIME()
+  call comm_sync_all
+  time_in=get_wtime()
 
-  if(Myrank == 0) then
+  if(comm_is_root()) then
     read(*,*) directory
   end if
-  call MPI_BCAST(directory,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
+  call comm_bcast(directory,proc_group(1))
 
-  write(cMyrank,'(I5.5)')Myrank
+  write(cMyrank,'(I5.5)')procid(1)
   file_reentrance=trim(directory)//'tmp_re.'//trim(cMyrank)
   open(500,file=file_reentrance,form='unformatted')
 
@@ -1212,10 +1210,8 @@ subroutine prep_Reentrance_Read
   read(500) FSset_option,MD_option
   read(500) AD_RHO !ovlp_option
 
-! MPI
-!  include 'mpif.h'
-!  integer :: Myrank,Nprocs,ierr
-!  integer :: NEW_COMM_WORLD,NEWPROCS,NEWRANK ! sato
+!  integer :: procid(1),Nprocs
+!  integer :: NEW_COMM_WORLD,nprocs(2),procid(2) ! sato
   read(500) NK_ave,NG_ave,NK_s,NK_e,NG_s,NG_e
   read(500) NK_remainder,NG_remainder
   read(500) etime1,etime2
@@ -1374,10 +1370,10 @@ subroutine prep_Reentrance_Read
 
   close(500)
 
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
-  time_out=MPI_WTIME()
+  call comm_sync_all
+  time_out=get_wtime()
 
-  if(myrank == 0)write(*,*)'Reentrance time read =',time_out-time_in,' sec'
+  if(comm_is_root())write(*,*)'Reentrance time read =',time_out-time_in,' sec'
 
   return
 end subroutine prep_Reentrance_Read
@@ -1385,13 +1381,15 @@ end subroutine prep_Reentrance_Read
 subroutine prep_Reentrance_write
   use Global_Variables
   use timelog, only: timelog_reentrance_write
+  use communication
+  use misc_routines
   implicit none
   real(8) :: time_in,time_out
 
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
-  time_in=MPI_WTIME()
+  call comm_sync_all
+  time_in=get_wtime()
 
-  if (Myrank == 0) then
+  if (comm_is_root()) then
     open(501,file=trim(directory)//trim(SYSname)//'_re.dat')
     write(501,*) "'reentrance'"! entrance_option
     write(501,*) Time_shutdown
@@ -1400,7 +1398,7 @@ subroutine prep_Reentrance_write
   end if
 
 
-  write(cMyrank,'(I5.5)')Myrank
+  write(cMyrank,'(I5.5)')procid(1)
 
   file_reentrance=trim(directory)//'tmp_re.'//trim(cMyrank)
   open(500,file=file_reentrance,form='unformatted')
@@ -1460,10 +1458,8 @@ subroutine prep_Reentrance_write
   write(500) FSset_option,MD_option
   write(500) AD_RHO !ovlp_option
 
-! MPI
-!  include 'mpif.h'
-!  integer :: Myrank,Nprocs,ierr
-!  integer :: NEW_COMM_WORLD,NEWPROCS,NEWRANK ! sato
+!  integer :: procid(1),Nprocs
+!  integer :: NEW_COMM_WORLD,nprocs(2),procid(2) ! sato
   write(500) NK_ave,NG_ave,NK_s,NK_e,NG_s,NG_e
   write(500) NK_remainder,NG_remainder
   write(500) etime1,etime2
@@ -1556,10 +1552,10 @@ subroutine prep_Reentrance_write
 !== write data ===!  
 
   close(500)
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
-  time_out=MPI_WTIME()
+  call comm_sync_all
+  time_out=get_wtime()
 
-  if(myrank == 0)write(*,*)'Reentrance time write =',time_out-time_in,' sec'
+  if(comm_is_root())write(*,*)'Reentrance time write =',time_out-time_in,' sec'
 
   return
 end subroutine prep_Reentrance_write
@@ -1567,12 +1563,13 @@ end subroutine prep_Reentrance_write
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 Subroutine err_finalize(err_message)
   use Global_Variables
+  use communication
   implicit none
   character(*),intent(in) :: err_message
-  if (Myrank == 0) then
+  if (comm_is_root()) then
     write(*,*) err_message
   endif
-  call MPI_FINALIZE(ierr)
+  call comm_finalize
 
   stop
 End Subroutine Err_finalize

--- a/main/sc.f90
+++ b/main/sc.f90
@@ -51,8 +51,8 @@ Program main
 
   if(comm_is_root())write(*,*)'NUMBER_THREADS = ',NUMBER_THREADS
 
-  etime1=MPI_WTIME()
-  Time_start=MPI_WTIME() !reentrance
+  etime1=get_wtime()
+  Time_start=get_wtime() !reentrance
   call comm_bcast(Time_start,proc_group(1))
   Rion_update='on'
 
@@ -171,14 +171,14 @@ Program main
       write(*,*) 'var_ave,var_max=',esp_var_ave(iter),esp_var_max(iter)
       write(*,*) 'dns. difference =',dns_diff(iter)
       if (iter/20*20 == iter) then
-         etime2=MPI_WTIME()
+         etime2=get_wtime()
          write(*,*) '====='
          write(*,*) 'elapse time=',etime2-etime1,'sec=',(etime2-etime1)/60,'min'
       end if
       write(*,*) '-----------------------------------------------'
     end if
   end do
-  etime2 = MPI_WTIME()
+  etime2 = get_wtime()
 
   if(comm_is_root()) then
     call timelog_set(LOG_DYNAMICS, etime2 - etime1)
@@ -217,7 +217,7 @@ Program main
   Eall0=Eall
   if(comm_is_root()) write(*,*) 'Eall =',Eall
 
-  etime2=MPI_WTIME()
+  etime2=get_wtime()
   if (comm_is_root()) then
     write(*,*) '-----------------------------------------------'
     write(*,*) 'static time=',etime2-etime1,'sec=', (etime2-etime1)/60,'min'
@@ -301,7 +301,7 @@ Program main
 #ifdef ARTED_USE_PAPI
   call papi_begin
 #endif
-  etime1=MPI_WTIME()
+  etime1=get_wtime()
 !$acc enter data copyin(zu)
   do iter=entrance_iter+1,Nt
     do ixyz=1,3
@@ -419,7 +419,7 @@ Program main
 
 
 !Timer
-    etime2=MPI_WTIME()
+    etime2=get_wtime()
     call timelog_set(LOG_DYNAMICS, etime2 - etime1)
     if (iter/1000*1000 == iter.and.comm_is_root()) then
       call timelog_show_hour('dynamics time      :', LOG_DYNAMICS)
@@ -429,7 +429,7 @@ Program main
     end if
 !Timer for shutdown
     if (iter/10*10 == iter) then
-      Time_now=MPI_WTIME()
+      Time_now=get_wtime()
       call comm_bcast(Time_now,proc_group(1))
       if (comm_is_root() .and. iter/100*100 == iter) then
         write(*,*) 'Total time =',(Time_now-Time_start)
@@ -447,7 +447,7 @@ Program main
     call timelog_end(LOG_OTHER)
   enddo !end of RT iteraction========================
 !$acc exit data copyout(zu)
-  etime2=MPI_WTIME()
+  etime2=get_wtime()
 #ifdef ARTED_USE_PAPI
   call papi_end
 #endif
@@ -499,7 +499,7 @@ Program main
   call comm_sync_all
 
   if (comm_is_root()) write(*,*) 'This is the end of all calculation'
-  Time_now=MPI_WTIME()
+  Time_now=get_wtime()
   if (comm_is_root() ) write(*,*) 'Total time =',(Time_now-Time_start)
 
 1 if(comm_is_root()) write(*,*)  'This calculation is shutdown successfully!'
@@ -940,14 +940,14 @@ End Subroutine Read_data
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 subroutine prep_Reentrance_Read
   use Global_Variables
-  use timelog,       only: timelog_reentrance_read
+  use timelog,       only: timelog_reentrance_read, get_wtime
   use opt_variables, only: opt_vars_initialize_p1, opt_vars_initialize_p2
   use communication
   implicit none
   real(8) :: time_in,time_out
 
   call comm_sync_all
-  time_in=MPI_WTIME()
+  time_in=get_wtime()
 
   if(comm_is_root()) then
     read(*,*) directory
@@ -1218,7 +1218,7 @@ subroutine prep_Reentrance_Read
   close(500)
 
   call comm_sync_all
-  time_out=MPI_WTIME()
+  time_out=get_wtime()
 
   if(comm_is_root())write(*,*)'Reentrance time read =',time_out-time_in,' sec'
 
@@ -1227,13 +1227,13 @@ end subroutine prep_Reentrance_Read
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 subroutine prep_Reentrance_write
   use Global_Variables
-  use timelog, only: timelog_reentrance_write
+  use timelog, only: timelog_reentrance_write, get_wtime
   use communication
   implicit none
   real(8) :: time_in,time_out
 
   call comm_sync_all
-  time_in=MPI_WTIME()
+  time_in=get_wtime()
 
   if (comm_is_root()) then
     open(501,file=trim(directory)//trim(SYSname)//'_re.dat')
@@ -1424,7 +1424,7 @@ subroutine prep_Reentrance_write
 
   close(500)
   call comm_sync_all
-  time_out=MPI_WTIME()
+  time_out=get_wtime()
 
   if(comm_is_root())write(*,*)'Reentrance time write =',time_out-time_in,' sec'
 

--- a/main/sc.f90
+++ b/main/sc.f90
@@ -24,38 +24,36 @@ Program main
   use opt_variables
   use environment
   use performance_analyzer
+  use communication
   implicit none
   integer :: iter,ik,ib,ia,i,ixyz
   character(3) :: Rion_update
   character(10) :: functional_t
 !$ integer :: omp_get_max_threads  
 
-  call MPI_init(ierr)
-  call MPI_COMM_SIZE(MPI_COMM_WORLD,Nprocs,ierr)
-  call MPI_COMM_RANK(MPI_COMM_WORLD,Myrank,ierr)
+  call comm_init
 
   call timelog_initialize
   call load_environments
 
-  if(Myrank == 0) then
+  if(comm_is_root()) then
     write(*,'(2A)')'ARTED ver. = ',ARTED_ver
     call print_optimize_message
   end if
 
-  NEW_COMM_WORLD=MPI_COMM_WORLD
   NUMBER_THREADS=1
 !$  NUMBER_THREADS=omp_get_max_threads()
 !$  if(iter*0 == 0) then
-!$    if(myrank == 0)write(*,*)'parallel = Hybrid'
+!$    if(comm_is_root())write(*,*)'parallel = Hybrid'
 !$  else
-  if(myrank == 0)write(*,*)'parallel = Flat MPI'
+  if(comm_is_root())write(*,*)'parallel = Flat MPI'
 !$  end if
 
-  if(myrank == 0)write(*,*)'NUMBER_THREADS = ',NUMBER_THREADS
+  if(comm_is_root())write(*,*)'NUMBER_THREADS = ',NUMBER_THREADS
 
   etime1=MPI_WTIME()
   Time_start=MPI_WTIME() !reentrance
-  call MPI_BCAST(Time_start,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
+  call comm_bcast(Time_start,proc_group(1))
   Rion_update='on'
 
   call Read_data
@@ -78,7 +76,7 @@ Program main
   rho_in(1:NL,1)=rho(1:NL)
   call input_pseudopotential_YS !shinohara
 !  call input_pseudopotential_KY !shinohara
-!  call MPI_FINALIZE(ierr) !!debug shinohara
+!  call comm_finalize !!debug shinohara
 !  stop !!debug shinohara
   call prep_ps_periodic('initial    ')
 
@@ -99,12 +97,12 @@ Program main
   if (MD_option /= 'Y') Rion_update = 'off'
   Eall_GS(0)=Eall
 
-  if(Myrank == 0) write(*,*) 'This is the end of preparation for ground state calculation'
-  if(Myrank == 0) write(*,*) '-----------------------------------------------------------'
+  if(comm_is_root()) write(*,*) 'This is the end of preparation for ground state calculation'
+  if(comm_is_root()) write(*,*) '-----------------------------------------------------------'
 
   call timelog_reset
   do iter=1,Nscf
-    if (Myrank == 0)  write(*,*) 'iter = ',iter
+    if (comm_is_root())  write(*,*) 'iter = ',iter
     if( kbTev < 0d0 )then ! sato
       if (FSset_option == 'Y') then
         if (iter/NFSset_every*NFSset_every == iter .and. iter >= NFSset_start) then
@@ -117,7 +115,7 @@ Program main
           if (minval(esp_cb_min(:))-maxval(esp_vb_max(:))<0.d0) then
             call Occupation_Redistribution
           else
-            if (Myrank == 0) then
+            if (comm_is_root()) then
               write(*,*) '======================================='
               write(*,*) 'occupation redistribution is not needed'
               write(*,*) '======================================='
@@ -127,7 +125,7 @@ Program main
       end if
     else if( iter /= 1 )then ! sato
       call Fermi_Dirac_distribution
-      if((Myrank == 0).and.(iter == Nscf))then
+      if((comm_is_root()).and.(iter == Nscf))then
         open(126,file='occ.out')
         do ik=1,NK
           do ib=1,NB
@@ -163,7 +161,7 @@ Program main
     esp_var_max(iter)=maxval(esp_var(:,:))
     dns_diff(iter)=sqrt(sum((rho_out(:,iter)-rho_in(:,iter))**2))*Hxyz
 
-    if (Myrank == 0) then
+    if (comm_is_root()) then
       write(*,*) 'Total Energy = ',Eall_GS(iter),Eall_GS(iter)-Eall_GS(iter-1)
       write(*,'(a28,3e15.6)') 'jav(1),jav(2),jav(3)= ',jav(1),jav(2),jav(3)
       write(*,'(4(i3,f12.6,2x))') (ib,esp(ib,1),ib=1,NB)
@@ -182,7 +180,7 @@ Program main
   end do
   etime2 = MPI_WTIME()
 
-  if(Myrank == 0) then
+  if(comm_is_root()) then
     call timelog_set(LOG_DYNAMICS, etime2 - etime1)
     call timelog_show_hour('Ground State time  :', LOG_DYNAMICS)
     call timelog_show_min ('CG time            :', LOG_CG)
@@ -199,7 +197,7 @@ Program main
     call timelog_show_min ('Total_Energy time  :', LOG_TOTAL_ENERGY)
     call timelog_show_min ('Ion_Force time     :', LOG_ION_FORCE)
   end if
-  if(Myrank == 0) write(*,*) 'This is the end of GS calculation'
+  if(comm_is_root()) write(*,*) 'This is the end of GS calculation'
 
   zu_GS0(:,:,:)=zu_GS(:,:,:)
 
@@ -217,17 +215,17 @@ Program main
   Vloc_GS(:)=Vloc(:)
   call Total_Energy_omp(Rion_update,'GS')
   Eall0=Eall
-  if(Myrank == 0) write(*,*) 'Eall =',Eall
+  if(comm_is_root()) write(*,*) 'Eall =',Eall
 
   etime2=MPI_WTIME()
-  if (Myrank == 0) then
+  if (comm_is_root()) then
     write(*,*) '-----------------------------------------------'
     write(*,*) 'static time=',etime2-etime1,'sec=', (etime2-etime1)/60,'min'
     write(*,*) '-----------------------------------------------'
   end if
   etime1=etime2
 
-  if (Myrank == 0) then
+  if (comm_is_root()) then
     write(*,*) '-----------------------------------------------'
     write(*,*) '----some information for Band map--------------'
     do ik=1,NK 
@@ -258,7 +256,7 @@ Program main
   call opt_vars_init_t4ppt()
 #endif
 
-  if(Myrank == 0) write(*,*) 'This is the end of preparation for Real time calculation'
+  if(comm_is_root()) write(*,*) 'This is the end of preparation for Real time calculation'
 
 !====RT calculation============================
 
@@ -277,7 +275,7 @@ Program main
     entrance_iter=-1
   end if
 
-  if (Myrank == 0) then
+  if (comm_is_root()) then
     open(7,file=file_epst,position = position_option)
     open(8,file=file_dns,position = position_option)
     open(9,file=file_force_dR,position = position_option)
@@ -287,7 +285,7 @@ Program main
     end if
   endif
 
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  call comm_sync_all
 
 !$acc enter data copyin(ik_table,ib_table)
 !$acc enter data copyin(lapx,lapy,lapz)
@@ -367,7 +365,7 @@ Program main
     endif
     Eall=Eall+Tion
 !write section
-    if (iter/10*10 == iter.and.Myrank == 0) then
+    if (iter/10*10 == iter.and.comm_is_root()) then
       write(*,'(1x,f10.4,8f12.6,f22.14)') iter*dt,&
            &E_ext(iter,1),E_tot(iter,1),&
            &E_ext(iter,2),E_tot(iter,2),&
@@ -381,7 +379,7 @@ Program main
       write(9,'(1x,100e16.6E3)') iter*dt,((force(ixyz,ia),ixyz=1,3),ia=1,NI),((dRion(ixyz,ia,iter),ixyz=1,3),ia=1,NI)
     endif
 !Dynamical Density
-    if (iter/100*100 == iter.and.Myrank == 0) then
+    if (iter/100*100 == iter.and.comm_is_root()) then
       write(8,'(1x,i10)') iter
       do i=1,NL
         write(8,'(1x,2e16.6E3)') rho(i),(rho(i)-rho_gs(i))
@@ -390,7 +388,7 @@ Program main
 
 
 !j_Ac writing
-    if(Myrank == 0)then
+    if(comm_is_root())then
       if (iter/1000*1000 == iter .or. iter == Nt) then
         open(407,file=file_j_ac)
         do i=0,Nt
@@ -405,7 +403,7 @@ Program main
 !Adiabatic evolution
     if (AD_RHO /= 'No' .and. iter/100*100 == iter) then
       call k_shift_wf(Rion_update,5)
-      if (Myrank == 0) then
+      if (comm_is_root()) then
         do ia=1,NI
           write(*,'(1x,i7,3f15.6)') ia,force(1,ia),force(2,ia),force(3,ia)
         end do
@@ -423,7 +421,7 @@ Program main
 !Timer
     etime2=MPI_WTIME()
     call timelog_set(LOG_DYNAMICS, etime2 - etime1)
-    if (iter/1000*1000 == iter.and.Myrank == 0) then
+    if (iter/1000*1000 == iter.and.comm_is_root()) then
       call timelog_show_hour('dynamics time      :', LOG_DYNAMICS)
       call timelog_show_min ('dt_evolve time     :', LOG_DT_EVOLVE)
       call timelog_show_min ('Hartree time       :', LOG_HARTREE)
@@ -432,13 +430,13 @@ Program main
 !Timer for shutdown
     if (iter/10*10 == iter) then
       Time_now=MPI_WTIME()
-      call MPI_BCAST(Time_now,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-      if (Myrank == 0 .and. iter/100*100 == iter) then
+      call comm_bcast(Time_now,proc_group(1))
+      if (comm_is_root() .and. iter/100*100 == iter) then
         write(*,*) 'Total time =',(Time_now-Time_start)
       end if
       if ((Time_now - Time_start)>Time_shutdown) then 
-        call MPI_BARRIER(MPI_COMM_WORLD,ierr)
-        write(*,*) Myrank,'iter =',iter
+        call comm_sync_all
+        write(*,*) procid(1),'iter =',iter
         iter_now=iter
 !$acc update self(zu)
         call prep_Reentrance_write
@@ -456,7 +454,7 @@ Program main
   call timelog_set(LOG_DYNAMICS, etime2 - etime1)
   call timelog_disable_verbose
 
-  if(Myrank == 0) then
+  if(comm_is_root()) then
 #ifdef ARTED_USE_PAPI
     call papi_result(timelog_get(LOG_DYNAMICS))
 #endif
@@ -478,7 +476,7 @@ Program main
   end if
   call write_performance(trim(directory)//'sc_performance')
 
-  if(Myrank == 0) then
+  if(comm_is_root()) then
     close(7)
     close(8)
     close(9)
@@ -488,7 +486,7 @@ Program main
     end if
   endif
 
-  if(Myrank == 0) write(*,*) 'This is the end of RT calculation'
+  if(comm_is_root()) write(*,*) 'This is the end of RT calculation'
 
 !====RT calculation===========================
 !====Analyzing calculation====================
@@ -498,14 +496,14 @@ Program main
 
   call Fourier_tr
 
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  call comm_sync_all
 
-  if (Myrank == 0) write(*,*) 'This is the end of all calculation'
+  if (comm_is_root()) write(*,*) 'This is the end of all calculation'
   Time_now=MPI_WTIME()
-  if (Myrank == 0 ) write(*,*) 'Total time =',(Time_now-Time_start)
+  if (comm_is_root() ) write(*,*) 'Total time =',(Time_now-Time_start)
 
-1 if(Myrank == 0) write(*,*)  'This calculation is shutdown successfully!'
-  call MPI_FINALIZE(ierr)
+1 if(comm_is_root()) write(*,*)  'This calculation is shutdown successfully!'
+  call comm_finalize
 
 End Program Main
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
@@ -513,22 +511,22 @@ Subroutine Read_data
   use Global_Variables
   use opt_variables, only: symmetric_load_balancing, is_symmetric_mode
   use environment
+  use communication
   implicit none
   integer :: ia,i,j
 
-  if (Myrank == 0) then
-    write(*,*) 'Nprocs=',Nprocs
-    write(*,*) 'Myrank=0:  ',Myrank
+  if (comm_is_root()) then
+    write(*,*) 'nprocs(1)=',nprocs(1)
+    write(*,*) 'procid(1)=0:  ',procid(1)
 
     read(*,*) entrance_option
     write(*,*) 'entrance_option=',entrance_option
     read(*,*) Time_shutdown
     write(*,*) 'Time_shutdown=',Time_shutdown,'sec'
-
   end if
 
-  call MPI_BCAST(entrance_option,10,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Time_shutdown,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
+  call comm_bcast(entrance_option,proc_group(1))
+  call comm_bcast(Time_shutdown,proc_group(1))
 
   if(entrance_option == 'reentrance') then
     call prep_Reentrance_Read
@@ -539,7 +537,7 @@ Subroutine Read_data
   end if
 
 
-  if(Myrank == 0)then
+  if(comm_is_root())then
     read(*,*) entrance_iter
     read(*,*) SYSname
     read(*,*) directory
@@ -587,46 +585,44 @@ Subroutine Read_data
     write(*,*) 'KbTev=',KbTev ! sato
   end if
 
-  call MPI_BCAST(SYSname,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(directory,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-!yabana
-  call MPI_BCAST(functional,10,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(cval,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-!yabana
+  call comm_bcast(SYSname,proc_group(1))
+  call comm_bcast(directory,proc_group(1))
+  call comm_bcast(functional,proc_group(1))
+  call comm_bcast(cval,proc_group(1))
 
-  call MPI_BCAST(ps_format,10,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)!shinohara
-  call MPI_BCAST(PSmask_option,1,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)!shinohara
-  call MPI_BCAST(alpha_mask,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr) !shinohara
-  call MPI_BCAST(gamma_mask,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr) !shinohara
-  call MPI_BCAST(eta_mask,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr) !shinohara
+  call comm_bcast(ps_format,proc_group(1))
+  call comm_bcast(PSmask_option,proc_group(1))
+  call comm_bcast(alpha_mask,proc_group(1))
+  call comm_bcast(gamma_mask,proc_group(1))
+  call comm_bcast(eta_mask,proc_group(1))
 
-  call MPI_BCAST(file_GS,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(file_RT,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(file_epst,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(file_epse,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(file_force_dR,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(file_j_ac,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)  
-  call MPI_BCAST(file_DoS,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(file_band,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(file_dns,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(file_ovlp,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(file_nex,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(aL,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(ax,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(ay,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(az,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Sym,1,MPI_Integer,0,MPI_COMM_WORLD,ierr) !sym
-  call MPI_BCAST(crystal_structure,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Nd,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(NLx,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(NLy,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(NLz,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(NKx,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(NKy,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(NKz,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(NEwald,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(aEwald,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(KbTev,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr) ! sato
+  call comm_bcast(file_GS,proc_group(1))
+  call comm_bcast(file_RT,proc_group(1))
+  call comm_bcast(file_epst,proc_group(1))
+  call comm_bcast(file_epse,proc_group(1))
+  call comm_bcast(file_force_dR,proc_group(1))
+  call comm_bcast(file_j_ac,proc_group(1))
+  call comm_bcast(file_DoS,proc_group(1))
+  call comm_bcast(file_band,proc_group(1))
+  call comm_bcast(file_dns,proc_group(1))
+  call comm_bcast(file_ovlp,proc_group(1))
+  call comm_bcast(file_nex,proc_group(1))
+  call comm_bcast(aL,proc_group(1))
+  call comm_bcast(ax,proc_group(1))
+  call comm_bcast(ay,proc_group(1))
+  call comm_bcast(az,proc_group(1))
+  call comm_bcast(Sym,proc_group(1))
+  call comm_bcast(crystal_structure,proc_group(1))
+  call comm_bcast(Nd,proc_group(1))
+  call comm_bcast(NLx,proc_group(1))
+  call comm_bcast(NLy,proc_group(1))
+  call comm_bcast(NLz,proc_group(1))
+  call comm_bcast(NKx,proc_group(1))
+  call comm_bcast(NKy,proc_group(1))
+  call comm_bcast(NKz,proc_group(1))
+  call comm_bcast(NEwald,proc_group(1))
+  call comm_bcast(aEwald,proc_group(1))
+  call comm_bcast(KbTev,proc_group(1))
 
 
 !sym ---
@@ -674,7 +670,7 @@ Subroutine Read_data
   if(mod(NKx,2)+mod(NKy,2)+mod(NKz,2) /= 0) call err_finalize('NKx,NKy,NKz /= even')
   if(mod(NLx,2)+mod(NLy,2)+mod(NLz,2) /= 0) call err_finalize('NLx,NLy,NLz /= even')
   
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  call comm_sync_all
 
   aLx=ax*aL;    aLy=ay*aL;    aLz=az*aL
   aLxyz=aLx*aLy*aLz
@@ -698,7 +694,7 @@ Subroutine Read_data
     end select
   else
     ! Use non-uniform k-points
-    if (myrank == 0) then
+    if (comm_is_root()) then
       write(*,*) "Use non-uniform k-points distribution"
       write(*,*) "file_kw=", file_kw
       open(410, file=file_kw, status="old")
@@ -706,44 +702,44 @@ Subroutine Read_data
       close(410)
       write(*,*) "NK=", NK, "NKxyz=", NKxyz      
     endif
-    call MPI_BCAST(NK,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-    call MPI_BCAST(NKxyz,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
+    call comm_bcast(NK,proc_group(1))
+    call comm_bcast(NKxyz,proc_group(1))
   endif
 
-  NK_ave=NK/Nprocs; NK_remainder=NK-NK_ave*Nprocs
-  NG_ave=NG/Nprocs; NG_remainder=NG-NG_ave*Nprocs
+  NK_ave=NK/nprocs(1); NK_remainder=NK-NK_ave*nprocs(1)
+  NG_ave=NG/nprocs(1); NG_remainder=NG-NG_ave*nprocs(1)
 
   if(is_symmetric_mode() == 1 .and. ENABLE_LOAD_BALANCER == 1) then
-    call symmetric_load_balancing(NK,NK_ave,NK_s,NK_e,NK_remainder,Myrank,Nprocs)
+    call symmetric_load_balancing(NK,NK_ave,NK_s,NK_e,NK_remainder,procid(1),nprocs(1))
   else
-    if (NK/Nprocs*Nprocs == NK) then
-      NK_s=NK_ave*Myrank+1
-      NK_e=NK_ave*(Myrank+1)
+    if (NK/nprocs(1)*nprocs(1) == NK) then
+      NK_s=NK_ave*procid(1)+1
+      NK_e=NK_ave*(procid(1)+1)
     else
-      if (Myrank < (Nprocs-1) - NK_remainder + 1) then
-        NK_s=NK_ave*Myrank+1
-        NK_e=NK_ave*(Myrank+1)
+      if (procid(1) < (nprocs(1)-1) - NK_remainder + 1) then
+        NK_s=NK_ave*procid(1)+1
+        NK_e=NK_ave*(procid(1)+1)
       else
-        NK_s=NK-(NK_ave+1)*((Nprocs-1)-Myrank)-NK_ave
-        NK_e=NK-(NK_ave+1)*((Nprocs-1)-Myrank)
+        NK_s=NK-(NK_ave+1)*((nprocs(1)-1)-procid(1))-NK_ave
+        NK_e=NK-(NK_ave+1)*((nprocs(1)-1)-procid(1))
       end if
     end if
-    if(Myrank == Nprocs-1 .and. NK_e /= NK) call err_finalize('prep. NK_e error')
+    if(procid(1) == nprocs(1)-1 .and. NK_e /= NK) call err_finalize('prep. NK_e error')
   end if
 
-  if (NG/Nprocs*Nprocs == NG) then
-    NG_s=NG_ave*Myrank+1
-    NG_e=NG_ave*(Myrank+1)
+  if (NG/nprocs(1)*nprocs(1) == NG) then
+    NG_s=NG_ave*procid(1)+1
+    NG_e=NG_ave*(procid(1)+1)
   else
-    if (Myrank < (Nprocs-1) - NG_remainder + 1) then
-      NG_s=NG_ave*Myrank+1
-      NG_e=NG_ave*(Myrank+1)
+    if (procid(1) < (nprocs(1)-1) - NG_remainder + 1) then
+      NG_s=NG_ave*procid(1)+1
+      NG_e=NG_ave*(procid(1)+1)
     else
-      NG_s=NG-(NG_ave+1)*((Nprocs-1)-Myrank)-NG_ave
-      NG_e=NG-(NG_ave+1)*((Nprocs-1)-Myrank) 
+      NG_s=NG-(NG_ave+1)*((nprocs(1)-1)-procid(1))-NG_ave
+      NG_e=NG-(NG_ave+1)*((nprocs(1)-1)-procid(1))
     end if
   end if
-  if(Myrank == Nprocs-1 .and. NG_e /= NG) call err_finalize('prep. NG_e error')
+  if(procid(1) == nprocs(1)-1 .and. NG_e /= NG) call err_finalize('prep. NG_e error')
 
   allocate(lap(-Nd:Nd),nab(-Nd:Nd))
   allocate(lapx(-Nd:Nd),lapy(-Nd:Nd),lapz(-Nd:Nd))
@@ -779,7 +775,7 @@ Subroutine Read_data
   allocate(itable_sym(Sym,NL)) ! sym
   allocate(rho_l(NL),rho_tmp1(NL),rho_tmp2(NL)) !sym
 
-  if (Myrank == 0) then
+  if (comm_is_root()) then
     read(*,*) NB,Nelec
     write(*,*) 'NB,Nelec=',NB,Nelec
   endif
@@ -790,10 +786,10 @@ Subroutine Read_data
   end if
 
 
-  call MPI_BCAST(Nelec,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr) ! sato
-  call MPI_BCAST(NB,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(NBoccmax,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  call comm_bcast(Nelec,proc_group(1)) ! sato
+  call comm_bcast(NB,proc_group(1))
+  call comm_bcast(NBoccmax,proc_group(1))
+  call comm_sync_all
   NKB=(NK_e-NK_s+1)*NBoccmax ! sato
 
   allocate(occ(NB,NK),wk(NK),esp(NB,NK))
@@ -806,7 +802,7 @@ Subroutine Read_data
   NBocc(:)=NBoccmax
   allocate(esp_vb_min(NK),esp_vb_max(NK)) !redistribution
   allocate(esp_cb_min(NK),esp_cb_max(NK)) !redistribution
-  if (Myrank == 0) then
+  if (comm_is_root()) then
     read(*,*) FSset_option
     read(*,*) Ncg
     read(*,*) Nmemory_MB,alpha_MB
@@ -829,34 +825,35 @@ Subroutine Read_data
     write(*,*) 'AD_RHO =', AD_RHO
     write(*,*) 'Nt,dt=',Nt,dt
   endif
-  call MPI_BCAST(FSset_option,1,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Ncg,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Nmemory_MB,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(alpha_MB,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(NFSset_start,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(NFSset_every,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Nscf,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(ext_field,2,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Longi_Trans,2,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(MD_option,1,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(AD_RHO,2,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Nt,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(dt,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(entrance_option,12,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-!  call MPI_BCAST(Time_shutdown,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(entrance_iter,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  call comm_bcast(FSset_option,proc_group(1))
+  call comm_bcast(Ncg,proc_group(1))
+  call comm_bcast(Nmemory_MB,proc_group(1))
+  call comm_bcast(alpha_MB,proc_group(1))
+  call comm_bcast(NFSset_start,proc_group(1))
+  call comm_bcast(NFSset_every,proc_group(1))
+  call comm_bcast(Nscf,proc_group(1))
+  call comm_bcast(ext_field,proc_group(1))
+  call comm_bcast(Longi_Trans,proc_group(1))
+  call comm_bcast(MD_option,proc_group(1))
+  call comm_bcast(AD_RHO,proc_group(1))
+  call comm_bcast(Nt,proc_group(1))
+  call comm_bcast(dt,proc_group(1))
+  call comm_bcast(entrance_option,proc_group(1))
+!  call comm_bcast(Time_shutdown,proc_group(1))
+  call comm_bcast(entrance_iter,proc_group(1))
+  call comm_sync_all
+
   if(ext_field /= 'LF' .and. ext_field /= 'LR' ) call err_finalize('incorrect option for ext_field')
   if(Longi_Trans /= 'Lo' .and. Longi_Trans /= 'Tr' ) call err_finalize('incorrect option for Longi_Trans')
   if(AD_RHO /= 'TD' .and. AD_RHO /= 'GS' .and. AD_RHO /= 'No' ) call err_finalize('incorrect option for Longi_Trans')
 
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  call comm_sync_all
 
   allocate(javt(0:Nt,3))
   allocate(Ac_ext(-1:Nt+1,3),Ac_ind(-1:Nt+1,3),Ac_tot(-1:Nt+1,3))
   allocate(E_ext(0:Nt,3),E_ind(0:Nt,3),E_tot(0:Nt,3))
 
-  if (Myrank == 0) then
+  if (comm_is_root()) then
     read(*,*) dAc
     read(*,*) Nomega,domega
     read(*,*) AE_shape
@@ -879,24 +876,24 @@ Subroutine Read_data
     write(*,*) '===========ion configuration================'
     write(*,*) 'NI,NE=',NI,NE
   endif
-  call MPI_BCAST(dAc,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Nomega,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(domega,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(AE_shape,8,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(IWcm2_1,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(tpulsefs_1,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(omegaev_1,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(phi_CEP_1,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Epdir_1,3,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(IWcm2_2,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(tpulsefs_2,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(omegaev_2,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(phi_CEP_2,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Epdir_2,3,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(T1_T2fs,1,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(NI,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(NE,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  call comm_bcast(dAc,proc_group(1))
+  call comm_bcast(Nomega,proc_group(1))
+  call comm_bcast(domega,proc_group(1))
+  call comm_bcast(AE_shape,proc_group(1))
+  call comm_bcast(IWcm2_1,proc_group(1))
+  call comm_bcast(tpulsefs_1,proc_group(1))
+  call comm_bcast(omegaev_1,proc_group(1))
+  call comm_bcast(phi_CEP_1,proc_group(1))
+  call comm_bcast(Epdir_1,proc_group(1))
+  call comm_bcast(IWcm2_2,proc_group(1))
+  call comm_bcast(tpulsefs_2,proc_group(1))
+  call comm_bcast(omegaev_2,proc_group(1))
+  call comm_bcast(phi_CEP_2,proc_group(1))
+  call comm_bcast(Epdir_2,proc_group(1))
+  call comm_bcast(T1_T2fs,proc_group(1))
+  call comm_bcast(NI,proc_group(1))
+  call comm_bcast(NE,proc_group(1))
+  call comm_sync_all
   if(AE_shape /= 'Asin2cos' .and. AE_shape /= 'Esin2sin' &
     &.and. AE_shape /= 'input' .and. AE_shape /= 'Asin2_cw' ) call err_finalize('incorrect option for AE_shape')
 
@@ -912,7 +909,7 @@ Subroutine Read_data
   allocate(udVtbl(Nrmax,0:Lmax,NE),dudVtbl(Nrmax,0:Lmax,NE))
   allocate(Floc(3,NI),Fnl(3,NI),Fion(3,NI))                         
 
-  if (Myrank == 0) then
+  if (comm_is_root()) then
     read(*,*) (Zatom(j),j=1,NE)
     read(*,*) (Lref(j),j=1,NE)
     do ia=1,NI
@@ -928,11 +925,11 @@ Subroutine Read_data
     end do
   endif
 
-  call MPI_BCAST(Zatom,NE,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Kion,NI,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Lref,NE,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  call MPI_BCAST(Rion,3*NI,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  call comm_bcast(Zatom,proc_group(1))
+  call comm_bcast(Kion,proc_group(1))
+  call comm_bcast(Lref,proc_group(1))
+  call comm_bcast(Rion,proc_group(1))
+  call comm_sync_all
 
   Rion(1,:)=Rion(1,:)*aLx
   Rion(2,:)=Rion(2,:)*aLy
@@ -945,18 +942,19 @@ subroutine prep_Reentrance_Read
   use Global_Variables
   use timelog,       only: timelog_reentrance_read
   use opt_variables, only: opt_vars_initialize_p1, opt_vars_initialize_p2
+  use communication
   implicit none
   real(8) :: time_in,time_out
 
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  call comm_sync_all
   time_in=MPI_WTIME()
 
-  if(Myrank == 0) then
+  if(comm_is_root()) then
     read(*,*) directory
   end if
-  call MPI_BCAST(directory,50,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
+  call comm_bcast(directory,proc_group(1))
 
-  write(cMyrank,'(I5.5)')Myrank
+  write(cMyrank,'(I5.5)')procid(1)
   file_reentrance=trim(directory)//'tmp_re.'//trim(cMyrank)
   open(500,file=file_reentrance,form='unformatted')
 
@@ -1042,10 +1040,8 @@ subroutine prep_Reentrance_Read
   read(500) cval ! cvalue for TBmBJ. If cval<=0, calculated in the program
 !yabana
 
-! MPI
-!  include 'mpif.h'
-!  read(500) Myrank,Nprocs,ierr
-!  read(500) NEW_COMM_WORLD,NEWPROCS,NEWRANK ! sato
+!  read(500) procid(1),nprocs(1),ierr
+!  read(500) proc_group(2),NEWPROCS,NEWRANK ! sato
   read(500) NK_ave,NG_ave,NK_s,NK_e,NG_s,NG_e
   read(500) NK_remainder,NG_remainder
   read(500) etime1,etime2
@@ -1221,10 +1217,10 @@ subroutine prep_Reentrance_Read
 
   close(500)
 
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  call comm_sync_all
   time_out=MPI_WTIME()
 
-  if(myrank == 0)write(*,*)'Reentrance time read =',time_out-time_in,' sec'
+  if(comm_is_root())write(*,*)'Reentrance time read =',time_out-time_in,' sec'
 
   return
 end subroutine prep_Reentrance_Read
@@ -1232,13 +1228,14 @@ end subroutine prep_Reentrance_Read
 subroutine prep_Reentrance_write
   use Global_Variables
   use timelog, only: timelog_reentrance_write
+  use communication
   implicit none
   real(8) :: time_in,time_out
 
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  call comm_sync_all
   time_in=MPI_WTIME()
 
-  if (Myrank == 0) then
+  if (comm_is_root()) then
     open(501,file=trim(directory)//trim(SYSname)//'_re.dat')
     write(501,*) "'reentrance'"! entrance_option
     write(501,*) Time_shutdown
@@ -1247,7 +1244,7 @@ subroutine prep_Reentrance_write
   end if
 
 
-  write(cMyrank,'(I5.5)')Myrank
+  write(cMyrank,'(I5.5)')procid(1)
 
   file_reentrance=trim(directory)//'tmp_re.'//trim(cMyrank)
   open(500,file=file_reentrance,form='unformatted')
@@ -1317,10 +1314,8 @@ subroutine prep_Reentrance_write
   write(500) cval ! cvalue for TBmBJ. If cval<=0, calculated in the program
 !yabana
 
-! MPI
-!  include 'mpif.h'
-!  write(500) Myrank,Nprocs,ierr
-!  write(500) NEW_COMM_WORLD,NEWPROCS,NEWRANK ! sato
+!  write(500) procid(1),nprocs(1),ierr
+!  write(500) proc_group(2),NEWPROCS,NEWRANK ! sato
   write(500) NK_ave,NG_ave,NK_s,NK_e,NG_s,NG_e
   write(500) NK_remainder,NG_remainder
   write(500) etime1,etime2
@@ -1428,10 +1423,10 @@ subroutine prep_Reentrance_write
 !== write data ===!  
 
   close(500)
-  call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+  call comm_sync_all
   time_out=MPI_WTIME()
 
-  if(myrank == 0)write(*,*)'Reentrance time write =',time_out-time_in,' sec'
+  if(comm_is_root())write(*,*)'Reentrance time write =',time_out-time_in,' sec'
 
   return
 end subroutine prep_Reentrance_write
@@ -1439,12 +1434,13 @@ end subroutine prep_Reentrance_write
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 Subroutine err_finalize(err_message)
   use Global_Variables
+  use communication
   implicit none
   character(*),intent(in) :: err_message
-  if (Myrank == 0) then
+  if (comm_is_root()) then
     write(*,*) err_message
   endif
-  call MPI_FINALIZE(ierr)
+  call comm_finalize
 
   stop
 End Subroutine Err_finalize

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES
     env_variables_internal.c
     papi_wrap.c
     nvtx.f90
+    communication.f90
     )
 #if (USE_NVTX)
 #   set(SOURCES ${SOURCES} nvtx.f90)

--- a/modules/communication.f90
+++ b/modules/communication.f90
@@ -1,0 +1,382 @@
+!
+!  Copyright 2016 ARTED developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+module communication
+  implicit none
+
+  integer, public, parameter :: ROOT_PROCID = 0
+
+  integer, public :: procid(2)
+  integer, public :: nprocs(2)
+  integer, public :: proc_group(2)
+
+  public :: comm_init
+  public :: comm_finalize
+  public :: comm_is_root
+  public :: comm_set_level2_group
+  public :: comm_sync_all
+  public :: comm_summation
+  public :: comm_bcast
+  public :: comm_get_min
+  public :: comm_get_max
+
+  type, public :: comm_maxloc_type
+    real(8) :: val
+    integer :: rank
+  end type
+
+  interface comm_summation
+    ! scalar
+    module procedure comm_summation_real8
+
+    ! 1-D array
+    module procedure comm_summation_array1d_real8
+
+    ! 2-D array
+    module procedure comm_summation_array2d_real8
+
+    ! 3-D array
+    module procedure comm_summation_array3d_real8
+  end interface
+
+  interface comm_bcast
+    ! scalar
+    module procedure comm_bcast_integer
+    module procedure comm_bcast_real8
+    module procedure comm_bcast_character
+    module procedure comm_bcast_logical
+
+    ! 1-D array
+    module procedure comm_bcast_array1d_integer
+    module procedure comm_bcast_array1d_real8
+
+    ! 2-D array
+    module procedure comm_bcast_array2d_integer
+    module procedure comm_bcast_array2d_real8
+
+    ! 3-D array
+    module procedure comm_bcast_array3d_real8
+  end interface
+
+  interface comm_get_min
+    ! 1-D array
+    module procedure comm_get_min_array1d_real8
+  end interface
+
+  interface comm_get_max
+    ! scalar
+    module procedure comm_get_maxloc
+
+    ! 1-D array
+    module procedure comm_get_max_array1d_real8
+  end interface
+
+  interface comm_logical_and
+    ! scalar
+    module procedure comm_logical_and_scalar
+  end interface
+
+  private :: get_rank, error_check
+
+#define MPI_ERROR_CHECK(x) x; call error_check(ierr)
+
+contains
+  subroutine comm_init
+    use mpi
+    implicit none
+    integer :: ierr
+    MPI_ERROR_CHECK(call MPI_Init(ierr))
+    proc_group(:) = MPI_COMM_WORLD
+    call get_rank(1)
+    call get_rank(2)
+  end subroutine
+
+  subroutine comm_finalize
+    use mpi
+    implicit none
+    integer :: ierr
+    MPI_ERROR_CHECK(call MPI_Finalize(ierr))
+  end subroutine
+
+  function comm_is_root(level)
+    implicit none
+    integer, intent(in), optional :: level
+    logical :: comm_is_root
+    if (present(level)) then
+      comm_is_root = procid(level) == ROOT_PROCID
+    else
+      comm_is_root = procid(1)     == ROOT_PROCID
+    end if
+  end function
+
+  subroutine comm_set_level2_group(nprocs, key)
+    use mpi
+    implicit none
+    integer, intent(in) :: nprocs, key
+    integer :: ierr
+    MPI_ERROR_CHECK(call MPI_Comm_split(proc_group(1), nprocs, key, proc_group(2), ierr))
+    call get_rank(2)
+  end subroutine
+
+  subroutine comm_sync_all(level)
+    use mpi
+    implicit none
+    integer, intent(in), optional :: level
+    integer :: ierr
+    if (present(level)) then
+      MPI_ERROR_CHECK(call MPI_Barrier(level, ierr))
+    else
+      MPI_ERROR_CHECK(call MPI_Barrier(proc_group(1), ierr))
+    end if
+  end subroutine
+
+
+  subroutine comm_summation_real8(invalue, outvalue, level)
+    use mpi
+    implicit none
+    real(8), intent(in)  :: invalue
+    real(8), intent(out) :: outvalue
+    integer, intent(in)  :: level
+    integer :: ierr
+    MPI_ERROR_CHECK(call MPI_Allreduce(invalue, outvalue, 1, MPI_REAL8, MPI_SUM, level, ierr))
+  end subroutine
+
+  subroutine comm_summation_array1d_real8(invalue, outvalue, N, level)
+    use mpi
+    implicit none
+    real(8), intent(in)  :: invalue(:)
+    real(8), intent(out) :: outvalue(:)
+    integer, intent(in)  :: N, level
+    integer :: ierr
+    MPI_ERROR_CHECK(call MPI_Allreduce(invalue, outvalue, N, MPI_REAL8, MPI_SUM, level, ierr))
+  end subroutine
+
+  subroutine comm_summation_array2d_real8(invalue, outvalue, N, level)
+    use mpi
+    implicit none
+    real(8), intent(in)  :: invalue(:,:)
+    real(8), intent(out) :: outvalue(:,:)
+    integer, intent(in)  :: N, level
+    integer :: ierr
+    MPI_ERROR_CHECK(call MPI_Allreduce(invalue, outvalue, N, MPI_REAL8, MPI_SUM, level, ierr))
+  end subroutine
+
+  subroutine comm_summation_array3d_real8(invalue, outvalue, N, level)
+    use mpi
+    implicit none
+    real(8), intent(in)  :: invalue(:,:,:)
+    real(8), intent(out) :: outvalue(:,:,:)
+    integer, intent(in)  :: N, level
+    integer :: ierr
+    MPI_ERROR_CHECK(call MPI_Allreduce(invalue, outvalue, N, MPI_REAL8, MPI_SUM, level, ierr))
+  end subroutine
+
+  subroutine comm_bcast_integer(val, level, root)
+    use mpi
+    implicit none
+    integer, intent(inout)        :: val
+    integer, intent(in)           :: level
+    integer, intent(in), optional :: root
+    integer :: rank, ierr
+    if (present(root)) then
+      rank = root
+    else
+      rank = 0
+    end if
+    MPI_ERROR_CHECK(call MPI_Bcast(val, 1, MPI_INTEGER, rank, level, ierr))
+  end subroutine
+
+  subroutine comm_bcast_real8(val, level, root)
+    use mpi
+    implicit none
+    real(8), intent(inout)        :: val
+    integer, intent(in)           :: level
+    integer, intent(in), optional :: root
+    integer :: rank, ierr
+    if (present(root)) then
+      rank = root
+    else
+      rank = 0
+    end if
+    MPI_ERROR_CHECK(call MPI_Bcast(val, 1, MPI_REAL8, rank, level, ierr))
+  end subroutine
+
+  subroutine comm_bcast_character(val, level, root)
+    use mpi
+    implicit none
+    character(*), intent(inout)        :: val
+    integer,      intent(in)           :: level
+    integer,      intent(in), optional :: root
+    integer :: rank, ierr
+    if (present(root)) then
+      rank = root
+    else
+      rank = 0
+    end if
+    MPI_ERROR_CHECK(call MPI_Bcast(val, len(val), MPI_CHARACTER, rank, level, ierr))
+  end subroutine
+
+  subroutine comm_bcast_logical(val, level, root)
+    use mpi
+    implicit none
+    logical, intent(inout)        :: val
+    integer, intent(in)           :: level
+    integer, intent(in), optional :: root
+    integer :: rank, ierr
+    if (present(root)) then
+      rank = root
+    else
+      rank = 0
+    end if
+    MPI_ERROR_CHECK(call MPI_Bcast(val, 1, MPI_LOGICAL, rank, level, ierr))
+  end subroutine
+
+  subroutine comm_bcast_array1d_integer(val, level, root)
+    use mpi
+    implicit none
+    integer, intent(inout)        :: val(:)
+    integer, intent(in)           :: level
+    integer, intent(in), optional :: root
+    integer :: rank, ierr
+    if (present(root)) then
+      rank = root
+    else
+      rank = 0
+    end if
+    MPI_ERROR_CHECK(call MPI_Bcast(val, size(val), MPI_INTEGER, rank, level, ierr))
+  end subroutine
+
+  subroutine comm_bcast_array1d_real8(val, level, root)
+    use mpi
+    implicit none
+    real(8), intent(inout)        :: val(:)
+    integer, intent(in)           :: level
+    integer, intent(in), optional :: root
+    integer :: rank, ierr
+    if (present(root)) then
+      rank = root
+    else
+      rank = 0
+    end if
+    MPI_ERROR_CHECK(call MPI_Bcast(val, size(val), MPI_REAL8, rank, level, ierr))
+  end subroutine
+
+  subroutine comm_bcast_array2d_integer(val, level, root)
+    use mpi
+    implicit none
+    integer, intent(inout)        :: val(:,:)
+    integer, intent(in)           :: level
+    integer, intent(in), optional :: root
+    integer :: rank, ierr
+    if (present(root)) then
+      rank = root
+    else
+      rank = 0
+    end if
+    MPI_ERROR_CHECK(call MPI_Bcast(val, size(val), MPI_INTEGER, rank, level, ierr))
+  end subroutine
+
+  subroutine comm_bcast_array2d_real8(val, level, root)
+    use mpi
+    implicit none
+    real(8), intent(inout)        :: val(:,:)
+    integer, intent(in)           :: level
+    integer, intent(in), optional :: root
+    integer :: rank, ierr
+    if (present(root)) then
+      rank = root
+    else
+      rank = 0
+    end if
+    MPI_ERROR_CHECK(call MPI_Bcast(val, size(val), MPI_REAL8, rank, level, ierr))
+  end subroutine
+
+  subroutine comm_bcast_array3d_real8(val, level, root)
+    use mpi
+    implicit none
+    real(8), intent(inout)        :: val(:,:,:)
+    integer, intent(in)           :: level
+    integer, intent(in), optional :: root
+    integer :: rank, ierr
+    if (present(root)) then
+      rank = root
+    else
+      rank = 0
+    end if
+    MPI_ERROR_CHECK(call MPI_Bcast(val, size(val), MPI_REAL8, rank, level, ierr))
+  end subroutine
+
+  subroutine comm_get_min_array1d_real8(invalue, outvalue, N, level)
+    use mpi
+    implicit none
+    real(8), intent(in)  :: invalue(:)
+    real(8), intent(out) :: outvalue(:)
+    integer, intent(in)  :: N, level
+    integer :: ierr
+    MPI_ERROR_CHECK(call MPI_Allreduce(invalue, outvalue, N, MPI_REAL8, MPI_MIN, level, ierr))
+  end subroutine
+
+  subroutine comm_get_max_array1d_real8(invalue, outvalue, N, level)
+    use mpi
+    implicit none
+    real(8), intent(in)  :: invalue(:)
+    real(8), intent(out) :: outvalue(:)
+    integer, intent(in)  :: N, level
+    integer :: ierr
+    MPI_ERROR_CHECK(call MPI_Allreduce(invalue, outvalue, N, MPI_REAL8, MPI_MAX, level, ierr))
+  end subroutine
+
+  subroutine comm_get_maxloc(invalue, outvalue, level)
+    use mpi
+    type(comm_maxloc_type), intent(in)  :: invalue
+    type(comm_maxloc_type), intent(out) :: outvalue
+    integer, intent(in)                 :: level
+    integer :: ierr
+    MPI_ERROR_CHECK(call MPI_Allreduce(invalue, outvalue, 1, MPI_DOUBLE_INT, MPI_MAXLOC, level, ierr))
+  end subroutine
+
+  subroutine comm_logical_and_scalar(invalue, outvalue, level)
+    use mpi
+    implicit none
+    logical, intent(in)  :: invalue
+    logical, intent(out) :: outvalue
+    integer, intent(in)  :: level
+    integer :: ierr
+    MPI_ERROR_CHECK(call MPI_Allreduce(invalue, outvalue, 1, MPI_LOGICAL, MPI_LAND, level, ierr))
+  end subroutine
+
+
+  subroutine get_rank(level)
+    use mpi
+    implicit none
+    integer, intent(in) :: level
+    integer :: ierr
+    MPI_ERROR_CHECK(call MPI_Comm_rank(proc_group(level), procid(level), ierr))
+    MPI_ERROR_CHECK(call MPI_Comm_size(proc_group(level), nprocs(level), ierr))
+  end subroutine
+
+  subroutine error_check(errcode)
+    use mpi
+    implicit none
+    integer, intent(in) :: errcode
+    character(MPI_MAX_ERROR_STRING) :: errstr
+    integer                         :: retlen, ierr
+    if (errcode /= MPI_SUCCESS) then
+      call MPI_Error_string(errcode, errstr, retlen, ierr)
+      print *, 'MPI Error:', errstr
+      call comm_finalize
+    end if
+  end subroutine
+end module

--- a/modules/global_variables_ms.f90
+++ b/modules/global_variables_ms.f90
@@ -145,10 +145,6 @@ Module Global_Variables
   real(8) :: cval ! cvalue for TBmBJ. If cval<=0, calculated in the program
 !yabana
 
-! MPI
-  include 'mpif.h'
-  integer :: Myrank,Nprocs,ierr
-  integer :: NEW_COMM_WORLD,NEWPROCS,NEWRANK ! sato
   integer :: NK_ave,NG_ave,NK_s,NK_e,NG_s,NG_e
   integer :: NK_remainder,NG_remainder
   real(8) :: etime1,etime2

--- a/modules/global_variables_sc.f90
+++ b/modules/global_variables_sc.f90
@@ -138,10 +138,6 @@ Module Global_Variables
   real(8) :: cval ! cvalue for TBmBJ. If cval<=0, calculated in the program
 !yabana
 
-! MPI
-  include 'mpif.h'
-  integer :: Myrank,Nprocs,ierr
-  integer :: NEW_COMM_WORLD,NEWPROCS,NEWRANK ! sato
   integer :: NK_ave,NG_ave,NK_s,NK_e,NG_s,NG_e
   integer :: NK_remainder,NG_remainder
   real(8) :: etime1,etime2

--- a/modules/timelog.f90
+++ b/modules/timelog.f90
@@ -152,11 +152,11 @@ contains
 #endif
   end subroutine
 
-  function get_elapse_time()
+  function get_wtime()
     implicit none
-    real(8) :: get_elapse_time
+    real(8) :: get_wtime
     real(8) :: omp_get_wtime
-    get_elapse_time = omp_get_wtime()
+    get_wtime = omp_get_wtime()
   end function
 
   subroutine timelog_begin(e)
@@ -167,7 +167,7 @@ contains
     call tlog_log_(e)
 #endif
     id = e - LOG_ID_OFFSET
-    log_temp(id) = get_elapse_time()
+    log_temp(id) = get_wtime()
   end subroutine
 
   subroutine timelog_end(e)
@@ -178,7 +178,7 @@ contains
     call tlog_log_(e + LOG_OUT_OFFSET)
 #endif
     id = e - LOG_ID_OFFSET
-    log_time(id) = log_time(id) + get_elapse_time() - log_temp(id)
+    log_time(id) = log_time(id) + get_wtime() - log_temp(id)
   end subroutine
 
   subroutine timelog_thread_begin(e)
@@ -191,7 +191,7 @@ contains
       call timelog_begin(e)
     end if
     id  = e - LOG_ID_OFFSET
-    log_temp_t(id,tid) = get_elapse_time()
+    log_temp_t(id,tid) = get_wtime()
   end subroutine
 
   subroutine timelog_thread_end(e)
@@ -204,7 +204,7 @@ contains
       call timelog_end(e)
     end if
     id = e - LOG_ID_OFFSET
-    log_time_t(id,tid) = log_time_t(id,tid) + get_elapse_time() - log_temp_t(id,tid)
+    log_time_t(id,tid) = log_time_t(id,tid) + get_wtime() - log_temp_t(id,tid)
   end subroutine
 
   subroutine timelog_show_hour(str, e)

--- a/perfcheck/stencil_perf_check.f90
+++ b/perfcheck/stencil_perf_check.f90
@@ -69,9 +69,6 @@ subroutine err_finalize(err_message)
   use Global_Variables
   implicit none
   character(*),intent(in) :: err_message
-  if (Myrank == 0) then
-    write(*,*) err_message
-  endif
-  call MPI_FINALIZE(ierr)
+  write(*,*) err_message
   stop
 end subroutine err_finalize

--- a/preparation/input_ps.f90
+++ b/preparation/input_ps.f90
@@ -15,12 +15,12 @@
 !
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 Subroutine input_pseudopotential_YS
-  use Global_Variables,only : Pi,Zatom,Mass,NE,directory,ierr,Myrank,ps_format,PSmask_option&
+  use Global_Variables,only : Pi,Zatom,Mass,NE,directory,ps_format,PSmask_option&
        &,Nrmax,Lmax,Mlps,Lref,Zps,NRloc,NRps,inorm&
        &,rad,Rps,vloctbl,udVtbl,radnl,Rloc,anorm,dvloctbl,dudVtbl &
        &,rho_nlcc_tbl,tau_nlcc_tbl,rho_nlcc,tau_nlcc,flag_nlcc,NL
+  use communication
   implicit none
-  include 'mpif.h'
   integer,parameter :: Lmax0=4,Nrmax0=50000
   real(8),parameter :: Eps0=1d-10
   integer :: ik,Mr,l,i
@@ -39,7 +39,7 @@ Subroutine input_pseudopotential_YS
   allocate(rho_nlcc(NL),tau_nlcc(NL))
   allocate(flag_nlcc_element(NE)); flag_nlcc_element(:) = .false. ;flag_nlcc = .false.
 
-  if (Myrank == 0) then
+  if (comm_is_root()) then
 ! --- Making prefix ---
     select case (ps_format)
     case('KY')        ; ps_postfix = '_rps.dat'
@@ -217,25 +217,25 @@ Subroutine input_pseudopotential_YS
     enddo
   endif
 
-  CALL MPI_BCAST(Zps,NE,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  CALL MPI_BCAST(Mlps,NE,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  CALL MPI_BCAST(Rps,NE,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  CALL MPI_BCAST(NRps,NE,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  CALL MPI_BCAST(NRloc,NE,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  CALL MPI_BCAST(Rloc,NE,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  CALL MPI_BCAST(anorm,(Lmax+1)*NE,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  CALL MPI_BCAST(inorm,(Lmax+1)*NE,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-  CALL MPI_BCAST(rad,Nrmax*NE,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  CALL MPI_BCAST(radnl,Nrmax*NE,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  CALL MPI_BCAST(vloctbl,Nrmax*NE,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  CALL MPI_BCAST(dvloctbl,Nrmax*NE,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  CALL MPI_BCAST(udVtbl,Nrmax*(Lmax+1)*NE,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  CALL MPI_BCAST(dudVtbl,Nrmax*(Lmax+1)*NE,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  CALL MPI_BCAST(Mass,NE,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  CALL MPI_BCAST(rho_nlcc_tbl,Nrmax*NE,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  CALL MPI_BCAST(tau_nlcc_tbl,Nrmax*NE,MPI_REAL8,0,MPI_COMM_WORLD,ierr)
-  CALL MPI_BCAST(flag_nlcc,NE,MPI_LOGICAL,0,MPI_COMM_WORLD,ierr)
-  if(myrank == 0)write(*,*)"flag_nlcc = ",flag_nlcc
+  call comm_bcast(Zps,proc_group(1))
+  call comm_bcast(Mlps,proc_group(1))
+  call comm_bcast(Rps,proc_group(1))
+  call comm_bcast(NRps,proc_group(1))
+  call comm_bcast(NRloc,proc_group(1))
+  call comm_bcast(Rloc,proc_group(1))
+  call comm_bcast(anorm,proc_group(1))
+  call comm_bcast(inorm,proc_group(1))
+  call comm_bcast(rad,proc_group(1))
+  call comm_bcast(radnl,proc_group(1))
+  call comm_bcast(vloctbl,proc_group(1))
+  call comm_bcast(dvloctbl,proc_group(1))
+  call comm_bcast(udVtbl,proc_group(1))
+  call comm_bcast(dudVtbl,proc_group(1))
+  call comm_bcast(Mass,proc_group(1))
+  call comm_bcast(rho_nlcc_tbl,proc_group(1))
+  call comm_bcast(tau_nlcc_tbl,proc_group(1))
+  call comm_bcast(flag_nlcc,proc_group(1))
+  if(comm_is_root()) write(*,*)"flag_nlcc = ",flag_nlcc
   return
   contains
 !====

--- a/preparation/prep_ps.f90
+++ b/preparation/prep_ps.f90
@@ -19,6 +19,7 @@
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 Subroutine prep_ps_periodic(property)
   use Global_Variables
+  use communication
   implicit none
   character(11) :: property
   integer :: ik,n,i,a,j,ix,iy,iz,lma,l,m,lm,ir,intr
@@ -106,10 +107,10 @@ Subroutine prep_ps_periodic(property)
   enddo
 !$omp end parallel
 
-  call MPI_ALLREDUCE(Vpsl_l,Vpsl,NL,MPI_REAL8,MPI_SUM,NEW_COMM_WORLD,ierr)
+  call comm_summation(Vpsl_l,Vpsl,NL,proc_group(2))
 
 ! nonlocal potential
-  if (Myrank == 0 .and. property=='initial') then
+  if (comm_is_root() .and. property=='initial') then
     write(*,*) ''
     write(*,*) '============nonlocal grid data=============='
   endif
@@ -132,7 +133,7 @@ Subroutine prep_ps_periodic(property)
     enddo
     enddo
     Mps(a)=j
-    if (Myrank == 0 .and. property == 'initial') then
+    if (comm_is_root() .and. property == 'initial') then
       write(*,*) 'a =',a,'Mps(a) =',Mps(a)
     endif
   end do
@@ -269,7 +270,7 @@ Subroutine prep_ps_periodic(property)
   rho_nlcc = 0d0
   tau_nlcc = 0d0
   if(flag_nlcc)then
-    if(myrank == 0)write(*,"(A)")"Preparation: Non-linear core correction"
+    if(comm_is_root())write(*,"(A)")"Preparation: Non-linear core correction"
     do a=1,NI
       ik=Kion(a)
       rc = 15d0 ! maximum


### PR DESCRIPTION
I created the communication module, which is simplified MPI.
The goal is make to abstraction of MPI.
For example, if you want that execute the application without MPI (e.g. your local computer), we can provide the non MPI parallelized application with _dummy_ communication module.

I verified the simulation with two input file (input_sc_SiO2.dat for single-cell and input_ms_Si.verify.dat for multi-scale)
However, I'd appreciate it if you could verify the simulation before or after merge.

Mapping MPI routines to communication module
===

comm_bcast _and_ comm_summation detects data size and data type automatically with _user-defined general name_.
But, comm_summation with vector requires data size because the routine requires source and result vectors.

|MPI variables, routines and codes|communication module|
|:-----|:-----|
|MPI_COMM_WORLD, NEW_COMM_WORLD|comm_group(1), comm_group(2)|
|Myrank, NEWRANK|procid(1), procid(2)|
|Nprocs, NEWPROCS|nprocs(1), nprocs(2)|
|call MPI_INIT(ierr)|call comm_init|
|call MPI_FINALIZE(ierr)|call comm_finalize|
|call MPI_BARRIER(MPI_COMM_WORLD,ierr)|call comm_sync_all|
|call MPI_BCAST(Var,N,MPI_REAL8,0,MPI_COMM_WORLD,ierr)|call comm_bcast(Var, proc_group(1))|
|call MPI_ALLREDUCE(Var_l,Var,N,MPI_REAL8,MPI_SUM,MPI_COMM_WORLD,ierr)|call comm_summation(Var_l,Var,N,proc_group(1))|
|t=MPI_WTIME()|t=get_wtime()|
|if (Myrank == 0) then|if (comm_is_root()) then _or_ if (comm_is_root(1)) then|
|if (NEWRANK == 0) then|if (comm_is_root(2)) then|
