### PR TITLE
Add option for using old propagator.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ option_set(ENABLE_LOOP_BLOCKING           "Enable loop blocking at the stencil" 
 option_set(ENABLE_SWPREFETCH              "Enable software prefetch in the explicit vec of stencil"  OFF)
 option_set(ENABLE_REDUCE_FOR_MANYCORE     "Enable optimized reduction code for many-core processor"  OFF)
 option_set(ENABLE_LARGE_BLOCKING          "Enable large blocking for accelerator"                    OFF)
+option_set(USE_OLD_PROPAGATOR             "Use old propagator for comparing to past results"         OFF)
 
 if (${BUILD_TARGET} STREQUAL "ms")
   add_definitions(-DARTED_MS)
@@ -126,6 +127,7 @@ endif ()
 add_definitions_if(OPT_CURRENT                -DARTED_CURRENT_OPTIMIZED)
 add_definitions_if(ENABLE_REDUCE_FOR_MANYCORE -DARTED_REDUCE_FOR_MANYCORE)
 add_definitions_if(ENABLE_LARGE_BLOCKING      -DARTED_LBLK)
+add_definitions_if(USE_OLD_PROPAGATOR         -DARTED_USE_OLD_PROPAGATOR)
 
 if (OPT_STENCIL)
   add_definitions(-DARTED_STENCIL_OPTIMIZED)

--- a/common/preprocessor.f90
+++ b/common/preprocessor.f90
@@ -56,4 +56,7 @@ subroutine print_optimize_message
 #ifdef ARTED_ENABLE_SOFTWARE_PREFETCH
   print *, '  ARTED_ENABLE_SOFTWARE_PREFETCH'
 #endif
+#ifdef ARTED_USE_OLD_PROPAGATOR
+  print *, '  ARTED_USE_OLD_PROPAGATOR'
+#endif
 end subroutine

--- a/configure.py
+++ b/configure.py
@@ -68,6 +68,7 @@ group.add_option('--domain-pow2',         action='store_true',  dest='domain_two
 group.add_option('--loop-blocking',       action='store_true',  dest='loop_blocking',     help='loop blocking applied to the stencil computation.')
 group.add_option('--opt-current',         action='store_true',  dest='current_optimized', help='enable the current routine optimization in RT.')
 group.add_option('--reduce-manycore',     action='store_true',  dest='reduce_manycore',   help='enable reduction code optimization for many-core processor.')
+group.add_option('--use-old-propagator',  action='store_true',  dest='old_propagator',    help='use old propagator for comparing to past simulation results.')
 parser.add_option_group(group)
 
 group = OptionGroup(parser, 'Debug options')
@@ -106,6 +107,7 @@ add_option(dict, 'ENABLE_EXPLICIT_VEC',        options.explicit_vec)
 add_option(dict, 'ENABLE_LOOP_BLOCKING',       options.loop_blocking)
 add_option(dict, 'ENABLE_SWPREFETCH',          options.swp)
 add_option(dict, 'ENABLE_REDUCE_FOR_MANYCORE', options.reduce_manycore)
+add_option(dict, 'USE_OLD_PROPAGATOR',         options.old_propagator)
 if options.simd is not None:
   dict['SIMD_SET'] = options.simd.upper()
 

--- a/main/ms.f90
+++ b/main/ms.f90
@@ -353,7 +353,12 @@ Program main
 ! sato ---------------------------------------
       call timelog_end(LOG_OTHER)
       
+#ifdef ARTED_USE_OLD_PROPAGATOR
       call dt_evolve_omp_KB_MS
+#else
+      !call dt_evolve_etrs_omp_KB_MS
+      call dt_evolve_omp_KB_MS
+#endif
 
       call timelog_begin(LOG_OTHER)
 ! sato ---------------------------------------

--- a/main/sc.f90
+++ b/main/sc.f90
@@ -327,8 +327,11 @@ Program main
     enddo
 !$acc update device(kAc)
 
-!    call dt_evolve_omp_KB(iter)
+#ifdef ARTED_USE_OLD_PROPAGATOR
+    call dt_evolve_omp_KB(iter)
+#else
     call dt_evolve_etrs_omp_KB(iter)
+#endif
     call current_omp_KB
 
     javt(iter+1,:)=jav(:)


### PR DESCRIPTION
I added cmake and configure.py parameters `USE_OLD_PROPAGATOR` and `--use-old-propagator`.
Sato-san added the new propagator ETRS which is faster than the old scheme.
However, I think that we should be provided the old scheme for comparing to past results.