### PR TITLE
Hotfix for multi-scale mode.

### DIFF
--- a/RT/dt_evolve.f90
+++ b/RT/dt_evolve.f90
@@ -178,6 +178,8 @@ Subroutine dt_evolve_omp_KB(iter)
   return
 End Subroutine dt_evolve_omp_KB
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
+!***If you created the ETRS propagator for multi-scale mode, please remove following directive.
+#ifdef ARTED_SC
 Subroutine dt_evolve_etrs_omp_KB(iter)
   use Global_Variables
   use timelog
@@ -357,6 +359,8 @@ Subroutine dt_evolve_etrs_omp_KB(iter)
 
   return
 End Subroutine dt_evolve_etrs_omp_KB
+!***If you created the ETRS propagator for multi-scale mode, please remove following directive.
+#endif
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 Subroutine dt_evolve_omp_KB_MS
   use Global_Variables


### PR DESCRIPTION
A compiler prints following errors when using ETRS propagator under multi-scale mode.
I fixed it temporarily.

    $ make
    ...
    [ 79%] Building Fortran object RT/CMakeFiles/RT.dir/dt_evolve.f90.o
    /work/xg00/x10002/arted/RT/dt_evolve.f90(238): error #6404: This name does not have a type, and must have an explicit type.   [VLOC_NEW]
      Vloc_new(:) = 3d0*Vloc(:) - 3d0*Vloc_old(:,1) + Vloc_old(:,2)
    --^
    /work/xg00/x10002/arted/RT/dt_evolve.f90(238): error #6514: Substring or array slice notation requires CHARACTER type or array.   [VLOC_NEW]
      Vloc_new(:) = 3d0*Vloc(:) - 3d0*Vloc_old(:,1) + Vloc_old(:,2)
    --^
    /work/xg00/x10002/arted/RT/dt_evolve.f90(238): error #6911: The syntax of this substring is invalid.   [VLOC_OLD]
      Vloc_new(:) = 3d0*Vloc(:) - 3d0*Vloc_old(:,1) + Vloc_old(:,2)
    ----------------------------------^