### PR TITLE
Add new input file module for dev_salmon

### DIFF
--- a/FDTD/FDTD.f90
+++ b/FDTD/FDTD.f90
@@ -165,7 +165,7 @@ subroutine init_Ac_ms
   wpulse_2=2*pi/tpulse_2
   T1_T2=T1_T2fs/0.02418d0 ! pulse_duration in a.u.
 
-  aY=40000d0
+!  aY=40000d0
 
   
   Elec=0d0

--- a/control/CMakeLists.txt
+++ b/control/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES
     control_sc.f90
     control_ms.f90
+    inputfile.f90
     )
 
 add_library(${CONTROL_LIB} STATIC ${SOURCES})

--- a/control/control_ms.f90
+++ b/control/control_ms.f90
@@ -611,16 +611,9 @@ Subroutine Read_data
   if (comm_is_root()) then
     write(*,*) 'Nprocs=',nprocs(1)
     write(*,*) 'procid(1)=0:  ',procid(1)
-
-    read(*,*) entrance_option
     write(*,*) 'entrance_option=',entrance_option
-    read(*,*) Time_shutdown
     write(*,*) 'Time_shutdown=',Time_shutdown,'sec'
-
   end if
-
-  call comm_bcast(entrance_option,proc_group(1))
-  call comm_bcast(Time_shutdown,proc_group(1))
 
   if(entrance_option == 'reentrance') then
     call err_finalize('Re-entrance function does not work now!')
@@ -633,30 +626,6 @@ Subroutine Read_data
 
 
   if(comm_is_root())then
-    read(*,*) entrance_iter
-    read(*,*) SYSname
-    read(*,*) directory
-!yabana
-    read(*,*) functional, cval
-!yabana
-    read(*,*) ps_format !shinohara
-    read(*,*) PSmask_option !shinohara
-    read(*,*) alpha_mask, gamma_mask, eta_mask !shinohara
-    read(*,*) aL,ax,ay,az
-    read(*,*) Sym,crystal_structure ! sym
-    read(*,*) Nd,NLx,NLy,NLz,NKx,NKy,NKz
-    if((NKx <= 0).or.(NKy <= 0).or.(NKz <= 0)) then
-      read(*,*) file_kw
-    endif
-    read(*,*) FDTDdim ! sato
-    read(*,*) TwoD_shape ! sato
-    read(*,*) NX_m,NY_m ! sato
-    read(*,*) HX_m,HY_m ! sato
-    read(*,*) NKsplit,NXYsplit ! sato
-    read(*,*) NXvacL_m,NXvacR_m ! sato
-    read(*,*) NEwald, aEwald
-    read(*,*) KbTev ! sato
-
     write(*,*) 'entrance_iter=',entrance_iter
     write(*,*) SYSname
     write(*,*) directory
@@ -691,19 +660,6 @@ Subroutine Read_data
     write(*,*) 'KbTev=',KbTev ! sato
   end if
 
-  call comm_bcast(SYSname,proc_group(1))
-  call comm_bcast(directory,proc_group(1))
-!yabana
-  call comm_bcast(functional,proc_group(1))
-  call comm_bcast(cval,proc_group(1))
-!yabana
-
-  call comm_bcast(ps_format,proc_group(1))!shinohara
-  call comm_bcast(PSmask_option,proc_group(1))!shinohara
-  call comm_bcast(alpha_mask,proc_group(1)) !shinohara
-  call comm_bcast(gamma_mask,proc_group(1)) !shinohara
-  call comm_bcast(eta_mask,proc_group(1)) !shinohara
-
   call comm_bcast(file_GS,proc_group(1))
   call comm_bcast(file_RT,proc_group(1))
   call comm_bcast(file_epst,proc_group(1))
@@ -716,32 +672,6 @@ Subroutine Read_data
   call comm_bcast(file_ovlp,proc_group(1))
   call comm_bcast(file_nex,proc_group(1))
   call comm_bcast(file_kw,proc_group(1))
-  call comm_bcast(aL,proc_group(1))
-  call comm_bcast(ax,proc_group(1))
-  call comm_bcast(ay,proc_group(1))
-  call comm_bcast(az,proc_group(1))
-  call comm_bcast(Sym,proc_group(1)) !sym
-  call comm_bcast(crystal_structure,proc_group(1))
-  call comm_bcast(Nd,proc_group(1))
-  call comm_bcast(NLx,proc_group(1))
-  call comm_bcast(NLy,proc_group(1))
-  call comm_bcast(NLz,proc_group(1))
-  call comm_bcast(NKx,proc_group(1))
-  call comm_bcast(NKy,proc_group(1))
-  call comm_bcast(NKz,proc_group(1))
-  call comm_bcast(FDTDdim,proc_group(1)) ! sato
-  call comm_bcast(TwoD_shape,proc_group(1)) ! sato
-  call comm_bcast(NX_m,proc_group(1)) ! sato
-  call comm_bcast(NY_m,proc_group(1)) ! sato
-  call comm_bcast(HX_m,proc_group(1)) ! sato
-  call comm_bcast(HY_m,proc_group(1)) ! sato
-  call comm_bcast(NKsplit,proc_group(1)) ! sato
-  call comm_bcast(NXYsplit,proc_group(1)) ! sato
-  call comm_bcast(NXvacL_m,proc_group(1)) ! sato
-  call comm_bcast(NXvacR_m,proc_group(1)) ! sato
-  call comm_bcast(NEwald,proc_group(1))
-  call comm_bcast(aEwald,proc_group(1))
-  call comm_bcast(KbTev,proc_group(1)) ! sato
 
   if(FDTDdim == '1D' .and. TwoD_shape /= 'periodic') then
      if(comm_is_root())write(*,*)'Warning !! 1D calculation ! TwoD_shape is not good'
@@ -930,7 +860,6 @@ Subroutine Read_data
   allocate(rho_l(NL),rho_tmp1(NL),rho_tmp2(NL)) !sym
 
   if (comm_is_root()) then
-    read(*,*) NB,Nelec
     write(*,*) 'NB,Nelec=',NB,Nelec
   endif
   if( kbTev < 0d0 )then ! sato
@@ -940,8 +869,6 @@ Subroutine Read_data
   end if
 
 
-  call comm_bcast(Nelec,proc_group(1)) ! sato
-  call comm_bcast(NB,proc_group(1))
   call comm_bcast(NBoccmax,proc_group(1))
   call comm_sync_all
   NKB=(NK_e-NK_s+1)*NBoccmax ! sato
@@ -957,18 +884,6 @@ Subroutine Read_data
   allocate(esp_vb_min(NK),esp_vb_max(NK)) !redistribution
   allocate(esp_cb_min(NK),esp_cb_max(NK)) !redistribution
   if (comm_is_root()) then
-    read(*,*) FSset_option
-    read(*,*) Ncg
-    read(*,*) Nmemory_MB,alpha_MB
-    read(*,*) NFSset_start,NFSset_every
-    read(*,*) Nscf
-!    read(*,*) ext_field
-!    read(*,*) Longi_Trans
-    Longi_Trans='Tr'
-    read(*,*) MD_option
-    read(*,*) AD_RHO
-    read(*,*) Nt,dt
-
     write(*,*) 'FSset_option =',FSset_option
     write(*,*) 'Ncg=',Ncg
     write(*,*) 'Nmemory_MB,alpha_MB =',Nmemory_MB,alpha_MB
@@ -980,22 +895,6 @@ Subroutine Read_data
     write(*,*) 'AD_RHO =', AD_RHO
     write(*,*) 'Nt,dt=',Nt,dt
   endif
-  call comm_bcast(FSset_option,proc_group(1))
-  call comm_bcast(Ncg,proc_group(1))
-  call comm_bcast(Nmemory_MB,proc_group(1))
-  call comm_bcast(alpha_MB,proc_group(1))
-  call comm_bcast(NFSset_start,proc_group(1))
-  call comm_bcast(NFSset_every,proc_group(1))
-  call comm_bcast(Nscf,proc_group(1))
-!  call comm_bcast(ext_field,proc_group(1))
-  call comm_bcast(Longi_Trans,proc_group(1))
-  call comm_bcast(MD_option,proc_group(1))
-  call comm_bcast(AD_RHO,proc_group(1))
-  call comm_bcast(Nt,proc_group(1))
-  call comm_bcast(dt,proc_group(1))
-  call comm_bcast(entrance_option,proc_group(1))
-!  call comm_bcast(Time_shutdown,proc_group(1))
-  call comm_bcast(entrance_iter,proc_group(1))
   call comm_sync_all
 !  if(ext_field /= 'LF' .and. ext_field /= 'LR' ) call err_finalize('incorrect option for ext_field')
 !  if(Longi_Trans /= 'Lo' .and. Longi_Trans /= 'Tr' ) call err_finalize('incorrect option for Longi_Trans')
@@ -1042,16 +941,6 @@ Subroutine Read_data
 ! sato ---------------------------------------------------------------------------------------
 
   if (comm_is_root()) then
-    read(*,*) dAc
-    read(*,*) Nomega,domega
-    read(*,*) AE_shape
-    read(*,*) IWcm2_1,tpulsefs_1,omegaev_1,phi_CEP_1
-    read(*,*) Epdir_1(1),Epdir_1(2),Epdir_1(3)
-    read(*,*) IWcm2_2,tpulsefs_2,omegaev_2,phi_CEP_2
-    read(*,*) Epdir_2(1),Epdir_2(2),Epdir_2(3)
-    read(*,*) T1_T2fs
-    read(*,*) NI,NE
-
     write(*,*) 'dAc=',dAc
     write(*,*) 'Nomega,etep=',Nomega,domega
     write(*,*) 'AE_shape=',AE_shape
@@ -1064,33 +953,17 @@ Subroutine Read_data
     write(*,*) '===========ion configuration================'
     write(*,*) 'NI,NE=',NI,NE
   endif
-  call comm_bcast(dAc,proc_group(1))
-  call comm_bcast(Nomega,proc_group(1))
-  call comm_bcast(domega,proc_group(1))
-  call comm_bcast(AE_shape,proc_group(1))
-  call comm_bcast(IWcm2_1,proc_group(1))
-  call comm_bcast(tpulsefs_1,proc_group(1))
-  call comm_bcast(omegaev_1,proc_group(1))
-  call comm_bcast(phi_CEP_1,proc_group(1))
-  call comm_bcast(Epdir_1,proc_group(1))
-  call comm_bcast(IWcm2_2,proc_group(1))
-  call comm_bcast(tpulsefs_2,proc_group(1))
-  call comm_bcast(omegaev_2,proc_group(1))
-  call comm_bcast(phi_CEP_2,proc_group(1))
-  call comm_bcast(Epdir_2,proc_group(1))
-  call comm_bcast(T1_T2fs,proc_group(1))
-  call comm_bcast(NI,proc_group(1))
-  call comm_bcast(NE,proc_group(1))
   call comm_sync_all
+
   if(AE_shape /= 'Asin2cos' .and. AE_shape /= 'Esin2sin' &
     &.and. AE_shape /= 'input' .and. AE_shape /= 'Asin2_cw' ) call err_finalize('incorrect option for AE_shape')
 
 
-  allocate(Zatom(NE),Kion(NI),Rps(NE),NRps(NE))
-  allocate(Rion(3,NI),Rion_eq(3,NI),dRion(3,NI,-1:Nt+1))
+  allocate(Rps(NE),NRps(NE))
+  allocate(Rion_eq(3,NI),dRion(3,NI,-1:Nt+1))
   allocate(Zps(NE),NRloc(NE),Rloc(NE),Mass(NE),force(3,NI))
   allocate(dVloc_G(NG_s:NG_e,NE),force_ion(3,NI))
-  allocate(Mps(NI),Lref(NE),Mlps(NE))
+  allocate(Mps(NI),Mlps(NE))
   allocate(anorm(0:Lmax,NE),inorm(0:Lmax,NE))
   allocate(rad(Nrmax,NE),vloctbl(Nrmax,NE),dvloctbl(Nrmax,NE))
   allocate(radnl(Nrmax,NE))
@@ -1098,12 +971,6 @@ Subroutine Read_data
   allocate(Floc(3,NI),Fnl(3,NI),Fion(3,NI))                         
 
   if (comm_is_root()) then
-    read(*,*) (Zatom(j),j=1,NE)
-    read(*,*) (Lref(j),j=1,NE)
-    do ia=1,NI
-      read(*,*) i,(Rion(j,ia),j=1,3),Kion(ia)
-    enddo
-
     write(*,*) 'Zatom=',(Zatom(j),j=1,NE)
     write(*,*) 'Lref=',(Lref(j),j=1,NE)
     write(*,*) 'i,Kion(ia)','(Rion(j,a),j=1,3)'
@@ -1112,11 +979,6 @@ Subroutine Read_data
       write(*,'(3f12.8)') (Rion(j,ia),j=1,3)
     end do
   endif
-
-  call comm_bcast(Zatom,proc_group(1))
-  call comm_bcast(Kion,proc_group(1))
-  call comm_bcast(Lref,proc_group(1))
-  call comm_bcast(Rion,proc_group(1))
   call comm_sync_all
 
   Rion(1,:)=Rion(1,:)*aLx
@@ -1137,11 +999,6 @@ subroutine prep_Reentrance_Read
 
   call comm_sync_all
   time_in=get_wtime()
-
-  if(comm_is_root()) then
-    read(*,*) directory
-  end if
-  call comm_bcast(directory,proc_group(1))
 
   write(cMyrank,'(I5.5)')procid(1)
   file_reentrance=trim(directory)//'tmp_re.'//trim(cMyrank)

--- a/control/control_sc.f90
+++ b/control/control_sc.f90
@@ -528,15 +528,9 @@ Subroutine Read_data
   if (comm_is_root()) then
     write(*,*) 'nprocs(1)=',nprocs(1)
     write(*,*) 'procid(1)=0:  ',procid(1)
-
-    read(*,*) entrance_option
     write(*,*) 'entrance_option=',entrance_option
-    read(*,*) Time_shutdown
     write(*,*) 'Time_shutdown=',Time_shutdown,'sec'
   end if
-
-  call comm_bcast(entrance_option,proc_group(1))
-  call comm_bcast(Time_shutdown,proc_group(1))
 
   if(entrance_option == 'reentrance') then
     call prep_Reentrance_Read
@@ -546,34 +540,12 @@ Subroutine Read_data
     call err_finalize('entrance_option /= new or reentrance')
   end if
 
-
   if(comm_is_root())then
-    read(*,*) entrance_iter
-    read(*,*) SYSname
-    read(*,*) directory
-!yabana
-    read(*,*) functional, cval
-!yabana
-    read(*,*) ps_format !shinohara
-    read(*,*) PSmask_option !shinohara
-    read(*,*) alpha_mask, gamma_mask, eta_mask !shinohara
-    read(*,*) aL,ax,ay,az
-    read(*,*) Sym,crystal_structure ! sym
-    read(*,*) Nd,NLx,NLy,NLz,NKx,NKy,NKz
-    !uemoto
-    if ((NKx <= 0) .or. (NKy <= 0) .or. (NKz <= 0)) then
-      read(*,*) file_kw
-    endif
-    read(*,*) NEwald, aEwald
-    read(*,*) KbTev ! sato
-
     write(*,*) 'entrance_iter=',entrance_iter
     write(*,*) SYSname
     write(*,*) directory
-!yabana
     write(*,*) 'functional=',functional
     if(functional == 'TBmBJ') write(*,*) 'cvalue=',cval
-!yabana
     write(*,*) 'ps_format =',ps_format !shinohara
     write(*,*) 'PSmask_option =',PSmask_option !shinohara
     write(*,*) 'alpha_mask, gamma_mask, eta_mask =',alpha_mask, gamma_mask, eta_mask !shinohara
@@ -595,17 +567,6 @@ Subroutine Read_data
     write(*,*) 'KbTev=',KbTev ! sato
   end if
 
-  call comm_bcast(SYSname,proc_group(1))
-  call comm_bcast(directory,proc_group(1))
-  call comm_bcast(functional,proc_group(1))
-  call comm_bcast(cval,proc_group(1))
-
-  call comm_bcast(ps_format,proc_group(1))
-  call comm_bcast(PSmask_option,proc_group(1))
-  call comm_bcast(alpha_mask,proc_group(1))
-  call comm_bcast(gamma_mask,proc_group(1))
-  call comm_bcast(eta_mask,proc_group(1))
-
   call comm_bcast(file_GS,proc_group(1))
   call comm_bcast(file_RT,proc_group(1))
   call comm_bcast(file_epst,proc_group(1))
@@ -617,23 +578,6 @@ Subroutine Read_data
   call comm_bcast(file_dns,proc_group(1))
   call comm_bcast(file_ovlp,proc_group(1))
   call comm_bcast(file_nex,proc_group(1))
-  call comm_bcast(aL,proc_group(1))
-  call comm_bcast(ax,proc_group(1))
-  call comm_bcast(ay,proc_group(1))
-  call comm_bcast(az,proc_group(1))
-  call comm_bcast(Sym,proc_group(1))
-  call comm_bcast(crystal_structure,proc_group(1))
-  call comm_bcast(Nd,proc_group(1))
-  call comm_bcast(NLx,proc_group(1))
-  call comm_bcast(NLy,proc_group(1))
-  call comm_bcast(NLz,proc_group(1))
-  call comm_bcast(NKx,proc_group(1))
-  call comm_bcast(NKy,proc_group(1))
-  call comm_bcast(NKz,proc_group(1))
-  call comm_bcast(NEwald,proc_group(1))
-  call comm_bcast(aEwald,proc_group(1))
-  call comm_bcast(KbTev,proc_group(1))
-
 
 !sym ---
   select case(crystal_structure)
@@ -787,7 +731,6 @@ Subroutine Read_data
   allocate(rho_l(NL),rho_tmp1(NL),rho_tmp2(NL)) !sym
 
   if (comm_is_root()) then
-    read(*,*) NB,Nelec
     write(*,*) 'NB,Nelec=',NB,Nelec
   endif
   if( kbTev < 0d0 )then ! sato
@@ -796,9 +739,6 @@ Subroutine Read_data
     NBoccmax=NB
   end if
 
-
-  call comm_bcast(Nelec,proc_group(1)) ! sato
-  call comm_bcast(NB,proc_group(1))
   call comm_bcast(NBoccmax,proc_group(1))
   call comm_sync_all
   NKB=(NK_e-NK_s+1)*NBoccmax ! sato
@@ -814,17 +754,6 @@ Subroutine Read_data
   allocate(esp_vb_min(NK),esp_vb_max(NK)) !redistribution
   allocate(esp_cb_min(NK),esp_cb_max(NK)) !redistribution
   if (comm_is_root()) then
-    read(*,*) FSset_option
-    read(*,*) Ncg
-    read(*,*) Nmemory_MB,alpha_MB
-    read(*,*) NFSset_start,NFSset_every
-    read(*,*) Nscf
-    read(*,*) ext_field
-    read(*,*) Longi_Trans
-    read(*,*) MD_option
-    read(*,*) AD_RHO
-    read(*,*) Nt,dt
-
     write(*,*) 'FSset_option =',FSset_option
     write(*,*) 'Ncg=',Ncg
     write(*,*) 'Nmemory_MB,alpha_MB =',Nmemory_MB,alpha_MB
@@ -836,22 +765,6 @@ Subroutine Read_data
     write(*,*) 'AD_RHO =', AD_RHO
     write(*,*) 'Nt,dt=',Nt,dt
   endif
-  call comm_bcast(FSset_option,proc_group(1))
-  call comm_bcast(Ncg,proc_group(1))
-  call comm_bcast(Nmemory_MB,proc_group(1))
-  call comm_bcast(alpha_MB,proc_group(1))
-  call comm_bcast(NFSset_start,proc_group(1))
-  call comm_bcast(NFSset_every,proc_group(1))
-  call comm_bcast(Nscf,proc_group(1))
-  call comm_bcast(ext_field,proc_group(1))
-  call comm_bcast(Longi_Trans,proc_group(1))
-  call comm_bcast(MD_option,proc_group(1))
-  call comm_bcast(AD_RHO,proc_group(1))
-  call comm_bcast(Nt,proc_group(1))
-  call comm_bcast(dt,proc_group(1))
-  call comm_bcast(entrance_option,proc_group(1))
-!  call comm_bcast(Time_shutdown,proc_group(1))
-  call comm_bcast(entrance_iter,proc_group(1))
   call comm_sync_all
 
   if(ext_field /= 'LF' .and. ext_field /= 'LR' ) call err_finalize('incorrect option for ext_field')
@@ -865,16 +778,6 @@ Subroutine Read_data
   allocate(E_ext(0:Nt,3),E_ind(0:Nt,3),E_tot(0:Nt,3))
 
   if (comm_is_root()) then
-    read(*,*) dAc
-    read(*,*) Nomega,domega
-    read(*,*) AE_shape
-    read(*,*) IWcm2_1,tpulsefs_1,omegaev_1,phi_CEP_1
-    read(*,*) Epdir_1(1),Epdir_1(2),Epdir_1(3)
-    read(*,*) IWcm2_2,tpulsefs_2,omegaev_2,phi_CEP_2
-    read(*,*) Epdir_2(1),Epdir_2(2),Epdir_2(3)
-    read(*,*) T1_T2fs
-    read(*,*) NI,NE
-
     write(*,*) 'dAc=',dAc
     write(*,*) 'Nomega,etep=',Nomega,domega
     write(*,*) 'AE_shape=',AE_shape
@@ -887,33 +790,16 @@ Subroutine Read_data
     write(*,*) '===========ion configuration================'
     write(*,*) 'NI,NE=',NI,NE
   endif
-  call comm_bcast(dAc,proc_group(1))
-  call comm_bcast(Nomega,proc_group(1))
-  call comm_bcast(domega,proc_group(1))
-  call comm_bcast(AE_shape,proc_group(1))
-  call comm_bcast(IWcm2_1,proc_group(1))
-  call comm_bcast(tpulsefs_1,proc_group(1))
-  call comm_bcast(omegaev_1,proc_group(1))
-  call comm_bcast(phi_CEP_1,proc_group(1))
-  call comm_bcast(Epdir_1,proc_group(1))
-  call comm_bcast(IWcm2_2,proc_group(1))
-  call comm_bcast(tpulsefs_2,proc_group(1))
-  call comm_bcast(omegaev_2,proc_group(1))
-  call comm_bcast(phi_CEP_2,proc_group(1))
-  call comm_bcast(Epdir_2,proc_group(1))
-  call comm_bcast(T1_T2fs,proc_group(1))
-  call comm_bcast(NI,proc_group(1))
-  call comm_bcast(NE,proc_group(1))
   call comm_sync_all
   if(AE_shape /= 'Asin2cos' .and. AE_shape /= 'Esin2sin' &
     &.and. AE_shape /= 'input' .and. AE_shape /= 'Asin2_cw' ) call err_finalize('incorrect option for AE_shape')
 
 
-  allocate(Zatom(NE),Kion(NI),Rps(NE),NRps(NE))
-  allocate(Rion(3,NI),Rion_eq(3,NI),dRion(3,NI,-1:Nt+1))
+  allocate(Rps(NE),NRps(NE))
+  allocate(Rion_eq(3,NI),dRion(3,NI,-1:Nt+1))
   allocate(Zps(NE),NRloc(NE),Rloc(NE),Mass(NE),force(3,NI))
   allocate(dVloc_G(NG_s:NG_e,NE),force_ion(3,NI))
-  allocate(Mps(NI),Lref(NE),Mlps(NE))
+  allocate(Mps(NI),Mlps(NE))
   allocate(anorm(0:Lmax,NE),inorm(0:Lmax,NE))
   allocate(rad(Nrmax,NE),vloctbl(Nrmax,NE),dvloctbl(Nrmax,NE))
   allocate(radnl(Nrmax,NE))
@@ -921,12 +807,6 @@ Subroutine Read_data
   allocate(Floc(3,NI),Fnl(3,NI),Fion(3,NI))                         
 
   if (comm_is_root()) then
-    read(*,*) (Zatom(j),j=1,NE)
-    read(*,*) (Lref(j),j=1,NE)
-    do ia=1,NI
-      read(*,*) i,(Rion(j,ia),j=1,3),Kion(ia)
-    enddo
-
     write(*,*) 'Zatom=',(Zatom(j),j=1,NE)
     write(*,*) 'Lref=',(Lref(j),j=1,NE)
     write(*,*) 'i,Kion(ia)','(Rion(j,a),j=1,3)'
@@ -935,11 +815,6 @@ Subroutine Read_data
       write(*,'(3f12.8)') (Rion(j,ia),j=1,3)
     end do
   endif
-
-  call comm_bcast(Zatom,proc_group(1))
-  call comm_bcast(Kion,proc_group(1))
-  call comm_bcast(Lref,proc_group(1))
-  call comm_bcast(Rion,proc_group(1))
   call comm_sync_all
 
   Rion(1,:)=Rion(1,:)*aLx
@@ -960,11 +835,6 @@ subroutine prep_Reentrance_Read
 
   call comm_sync_all
   time_in=get_wtime()
-
-  if(comm_is_root()) then
-    read(*,*) directory
-  end if
-  call comm_bcast(directory,proc_group(1))
 
   write(cMyrank,'(I5.5)')procid(1)
   file_reentrance=trim(directory)//'tmp_re.'//trim(cMyrank)

--- a/control/inputfile.f90
+++ b/control/inputfile.f90
@@ -1,0 +1,546 @@
+!
+!  Copyright 2016 ARTED developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+!--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
+module inputfile
+  implicit none
+  
+  integer, parameter :: fh_namelist = 901
+  integer, parameter :: fh_atomic_spiecies = 902
+  integer, parameter :: fh_atomic_positions = 903
+
+  integer :: inml_control
+  integer :: inml_system
+  integer :: inml_incident
+  integer :: inml_rgrid
+  integer :: inml_kgrid
+  integer :: inml_tstep
+  integer :: inml_electrons
+  integer :: inml_pseudo
+  integer :: inml_response
+  integer :: inml_multiscale
+  
+  
+  
+contains
+
+
+
+  subroutine extract_stdin()
+    use communication, only: comm_is_root, comm_sync_all
+    implicit none
+    
+    integer :: cur = fh_namelist
+    integer :: ret = 0
+    character(100) :: buff, text
+    
+    if (comm_is_root()) then
+      open(fh_namelist, file='.namelist.tmp', status='replace')
+      open(fh_atomic_spiecies, file='.atomic_spiecies.tmp', status='replace')
+      open(fh_atomic_positions, file='.atomic_positions.tmp', status='replace')
+      
+      do while (.true.)
+        read(*, '(a)', iostat=ret) buff
+        if (ret < 0) then
+          exit
+        else
+          text = trim(adjustl(buff))
+          ! Comment lines
+          if (text(1:1) == '!') cycle
+          ! Beginning of 'atomic_species' part
+          if (text == '&atomic_spiecies') then
+            cur = fh_atomic_spiecies
+            cycle
+          end if
+          ! Beginning of 'atomic_positions' part
+          if (text == '&atomic_positions') then
+            cur = fh_atomic_positions
+            cycle
+          end if
+          ! End of 'atomic_(spiecies|positions)' part
+          if ((text == '/') .and. (cur /= fh_namelist)) then
+            cur = fh_namelist
+            cycle
+          end if
+          
+          write(cur, '(a)') text
+        end if
+      end do
+      close(fh_namelist)
+      close(fh_atomic_positions)
+      close(fh_atomic_spiecies)
+    end if
+    call comm_sync_all()
+    return
+  end subroutine extract_stdin
+
+  
+  
+  subroutine set_default_param()
+    use Global_Variables
+    implicit none
+    ! control
+    entrance_option = 'new'
+    Time_shutdown = 86400
+    entrance_iter = 0
+    SYSname = ''
+    directory = './'
+    ! system
+    functional = ''
+    cval = 1
+    aL = 0
+    ax = 0
+    ay = 0
+    az = 0
+    Sym = -1
+    crystal_structure = ''
+    NB = 0
+    Nelec = 0
+    ext_field = ''
+    MD_option = 'N'
+    AD_RHO = 'N'
+    NE = 0
+    NI = 0
+    ! rgrid
+    Nd = 4
+    NLx = 0
+    NLy = 0
+    NLz = 0
+    ! kgrid
+    NKx = 0
+    NKy = 0
+    NKz = 0
+    file_kw = ''
+    ! tstep
+    Nt = -1
+    dt = 0
+    ! pseudo
+    ps_format = ''
+    PSmask_option = 'n'
+    alpha_mask = 0.8
+    gamma_mask = 1.8
+    eta_mask = 15
+    ! electrons
+    NEwald = 4
+    aEwald = 0.5
+    KbTev = 0
+    Ncg = 5
+    Nmemory_MB = 8
+    alpha_MB = 0.75
+    FSset_option = 'N'
+    NFSset_start = 75
+    NFSset_every = 25
+    Nscf = 0
+    ! incident
+    Longi_Trans = 'Tr'
+    dAc = 0
+    AE_shape = ''
+    IWcm2_1 = 0
+    tpulsefs_1 = 0
+    omegaev_1 = 0
+    phi_CEP_1 = 0
+    Epdir_1 = (/0,0,0/)
+    IWcm2_2 = 0
+    tpulsefs_2 = 0
+    omegaev_2 = 0
+    phi_CEP_2 = 0
+    Epdir_2 = (/0,0,0/)
+    T1_T2fs = 0
+    ! response
+    Nomega = -1
+    domega = 0
+    ! multiscale
+    FDTDdim = ""
+    TwoD_shape = ""
+    NX_m = 0
+    NY_m = 0
+    HX_m = 0
+    HY_m = 0
+    NKsplit = 0
+    NXYsplit = 0
+    NXvacL_m = 0
+    NXvacR_m = 0
+    return
+  end subroutine set_default_param
+
+  
+  subroutine read_namelist()
+    use communication, only: comm_is_root, comm_bcast, comm_sync_all, proc_group
+    use Global_Variables
+    implicit none
+    
+    namelist/control/ &
+            & entrance_option, &
+            & Time_shutdown, &
+            & entrance_iter, &
+            & SYSname, &
+            & directory
+    namelist/system/ &
+            & functional, &
+            & cval, &
+            & aL, &
+            & ax, &
+            & ay, &
+            & az, &
+            & Sym, &
+            & crystal_structure, &
+            & NB, &
+            & Nelec, &
+            & ext_field, &
+            & MD_option, &
+            & AD_RHO, &
+            & NE, &
+            & NI
+    namelist/rgrid/ &
+            & Nd, &
+            & NLx, &
+            & NLy, &
+            & NLz
+    namelist/kgrid/ &
+            & NKx, &
+            & NKy, &
+            & NKz, &
+            & file_kw
+    namelist/tstep/ &
+            & Nt, &
+            & dt
+    namelist/pseudo/ &
+            & ps_format, &
+            & PSmask_option, &
+            & alpha_mask, &
+            & gamma_mask, &
+            & eta_mask
+    namelist/electrons/ &
+            & NEwald, &
+            & aEwald, &
+            & KbTev, &
+            & Ncg, &
+            & Nmemory_MB, &
+            & alpha_MB, &
+            & FSset_option, &
+            & NFSset_start, &
+            & NFSset_every, &
+            & Nscf
+    namelist/incident/ &
+            & Longi_Trans, &
+            & dAc, &
+            & AE_shape, &
+            & IWcm2_1, &
+            & tpulsefs_1, &
+            & omegaev_1, &
+            & phi_CEP_1, &
+            & Epdir_1, &
+            & IWcm2_2, &
+            & tpulsefs_2, &
+            & omegaev_2, &
+            & phi_CEP_2, &
+            & Epdir_2, &
+            & T1_T2fs
+    namelist/response/ &
+            & Nomega, &
+            & domega
+    namelist/multiscale/ &
+            & FDTDdim, &
+            & TwoD_shape, &
+            & NX_m, &
+            & NY_m, &
+            & HX_m, &
+            & HY_m, &
+            & NKsplit, &
+            & NXYsplit, &
+            & NXvacL_m, &
+            & NXvacR_m
+      
+    if (comm_is_root()) then
+      call set_default_param()
+      
+      open(fh_namelist, file='.namelist.tmp', status='old')
+      read(fh_namelist, nml=control, iostat=inml_control)
+      rewind(fh_namelist)
+      read(fh_namelist, nml=system, iostat=inml_system)
+      rewind(fh_namelist)
+      read(fh_namelist, nml=incident, iostat=inml_incident)
+      rewind(fh_namelist)
+      read(fh_namelist, nml=rgrid, iostat=inml_rgrid)
+      rewind(fh_namelist)
+      read(fh_namelist, nml=kgrid, iostat=inml_kgrid)
+      rewind(fh_namelist)
+      read(fh_namelist, nml=tstep, iostat=inml_tstep)
+      rewind(fh_namelist)
+      read(fh_namelist, nml=electrons, iostat=inml_electrons)
+      rewind(fh_namelist)
+      read(fh_namelist, nml=pseudo, iostat=inml_pseudo)
+      rewind(fh_namelist)
+      read(fh_namelist, nml=response, iostat=inml_response)
+      rewind(fh_namelist)
+      read(fh_namelist, nml=multiscale, iostat=inml_multiscale)
+      close(fh_namelist)
+    end if
+    
+    call comm_bcast(entrance_option, proc_group(1))
+    call comm_bcast(Time_shutdown, proc_group(1))
+    call comm_bcast(entrance_iter, proc_group(1))
+    call comm_bcast(SYSname, proc_group(1))
+    call comm_bcast(directory, proc_group(1))
+    call comm_bcast(functional, proc_group(1))
+    call comm_bcast(cval, proc_group(1))
+    call comm_bcast(aL, proc_group(1))
+    call comm_bcast(ax, proc_group(1))
+    call comm_bcast(ay, proc_group(1))
+    call comm_bcast(az, proc_group(1))
+    call comm_bcast(Sym, proc_group(1))
+    call comm_bcast(crystal_structure, proc_group(1))
+    call comm_bcast(NB, proc_group(1))
+    call comm_bcast(Nelec, proc_group(1))
+    call comm_bcast(ext_field, proc_group(1))
+    call comm_bcast(MD_option, proc_group(1))
+    call comm_bcast(AD_RHO, proc_group(1))
+    call comm_bcast(NE, proc_group(1))
+    call comm_bcast(NI, proc_group(1))
+    call comm_bcast(Nd, proc_group(1))
+    call comm_bcast(NLx, proc_group(1))
+    call comm_bcast(NLy, proc_group(1))
+    call comm_bcast(NLz, proc_group(1))
+    call comm_bcast(NKx, proc_group(1))
+    call comm_bcast(NKy, proc_group(1))
+    call comm_bcast(NKz, proc_group(1))
+    call comm_bcast(file_kw, proc_group(1))
+    call comm_bcast(Nt, proc_group(1))
+    call comm_bcast(dt, proc_group(1))
+    call comm_bcast(ps_format, proc_group(1))
+    call comm_bcast(PSmask_option, proc_group(1))
+    call comm_bcast(alpha_mask, proc_group(1))
+    call comm_bcast(gamma_mask, proc_group(1))
+    call comm_bcast(eta_mask, proc_group(1))
+    call comm_bcast(NEwald, proc_group(1))
+    call comm_bcast(aEwald, proc_group(1))
+    call comm_bcast(KbTev, proc_group(1))
+    call comm_bcast(Ncg, proc_group(1))
+    call comm_bcast(Nmemory_MB, proc_group(1))
+    call comm_bcast(alpha_MB, proc_group(1))
+    call comm_bcast(FSset_option, proc_group(1))
+    call comm_bcast(NFSset_start, proc_group(1))
+    call comm_bcast(NFSset_every, proc_group(1))
+    call comm_bcast(Nscf, proc_group(1))
+    call comm_bcast(Longi_Trans, proc_group(1))
+    call comm_bcast(dAc, proc_group(1))
+    call comm_bcast(AE_shape, proc_group(1))
+    call comm_bcast(IWcm2_1, proc_group(1))
+    call comm_bcast(tpulsefs_1, proc_group(1))
+    call comm_bcast(omegaev_1, proc_group(1))
+    call comm_bcast(phi_CEP_1, proc_group(1))
+    call comm_bcast(Epdir_1, proc_group(1))
+    call comm_bcast(IWcm2_2, proc_group(1))
+    call comm_bcast(tpulsefs_2, proc_group(1))
+    call comm_bcast(omegaev_2, proc_group(1))
+    call comm_bcast(phi_CEP_2, proc_group(1))
+    call comm_bcast(Epdir_2, proc_group(1))
+    call comm_bcast(T1_T2fs, proc_group(1))
+    call comm_bcast(Nomega, proc_group(1))
+    call comm_bcast(domega, proc_group(1))
+    call comm_bcast(FDTDdim, proc_group(1))
+    call comm_bcast(TwoD_shape, proc_group(1))
+    call comm_bcast(NX_m, proc_group(1))
+    call comm_bcast(NY_m, proc_group(1))
+    call comm_bcast(HX_m, proc_group(1))
+    call comm_bcast(HY_m, proc_group(1))
+    call comm_bcast(NKsplit, proc_group(1))
+    call comm_bcast(NXYsplit, proc_group(1))
+    call comm_bcast(NXvacL_m, proc_group(1))
+    call comm_bcast(NXvacR_m, proc_group(1))
+    call comm_sync_all()
+    return
+  end subroutine read_namelist
+
+
+  subroutine read_atomic_spiecies()
+    use communication, only: comm_is_root, comm_bcast, comm_sync_all, proc_group
+    use Global_Variables, only: NE, Zatom, Lref
+    implicit none
+    integer :: i, index, Zatom_tmp, Lref_tmp
+    
+    allocate(Zatom(NE), Lref(NE))
+    
+    if (comm_is_root()) then
+      open(fh_atomic_spiecies, file='.atomic_spiecies.tmp', status='old')
+      do i=1, NE
+        read(fh_atomic_spiecies, *) index, zatom_tmp, lref_tmp
+        if (i == index) then
+          Zatom(i) = Zatom_tmp
+          Lref(i) = Lref_tmp
+        else
+          call err_finalize('atomic_spiecies is not ordered')
+        end if
+      end do
+      close(fh_atomic_positions)
+    end if
+    call comm_bcast(Zatom, proc_group(1))
+    call comm_bcast(Lref, proc_group(1))
+    call comm_sync_all()
+    return
+  end subroutine
+
+
+  subroutine read_atomic_positions()
+    use communication, only: comm_is_root, comm_bcast, comm_sync_all, proc_group
+    use Global_Variables, only: NI, Rion, Kion
+    implicit none
+    integer :: i, index, Kion_tmp
+    real(8) :: Rion_tmp(3)
+    
+    allocate(Rion(3,NI), Kion(NI))
+    
+    if (comm_is_root()) then
+      open(fh_atomic_positions, file='.atomic_positions.tmp', status='old')
+      do i=1, NI
+        read(fh_atomic_positions, *) index, Rion_tmp, Kion_tmp
+        if (i == index) then
+          Rion(:,i) = Rion_tmp
+          Kion(i) = Kion_tmp
+        else
+          call err_finalize('atomic_positions is not ordered')
+        end if
+      end do
+      close(fh_atomic_positions)
+    end if
+    call comm_bcast(Rion, proc_group(1))
+    call comm_bcast(Kion, proc_group(1))
+    call comm_sync_all()
+    return
+  end subroutine read_atomic_positions
+
+
+
+
+
+  subroutine read_input()
+    implicit none
+    
+    call extract_stdin()
+    call read_namelist()
+    call read_atomic_spiecies()
+    call read_atomic_positions()
+    
+    return
+  end subroutine read_input
+  
+  
+  
+  subroutine dump_inputdata()
+    use communication, only: comm_is_root, comm_sync_all
+    use Global_Variables
+    implicit none
+    integer :: i
+  
+    if (comm_is_root()) then
+      print '("#namelist: ",A,", status=",I1)', 'control', inml_control
+      print '("#",4X,A,"=",A)', 'entrance_option', entrance_option
+      print '("#",4X,A,"=",ES12.5)', 'Time_shutdown', Time_shutdown
+      print '("#",4X,A,"=",I1)', 'entrance_iter', entrance_iter
+      print '("#",4X,A,"=",A)', 'SYSname', SYSname
+      print '("#",4X,A,"=",A)', 'directory', directory
+      print '("#namelist: ",A,", status=",I1)', 'system', inml_system
+      print '("#",4X,A,"=",A)', 'functional', functional
+      print '("#",4X,A,"=",ES12.5)', 'cval', cval
+      print '("#",4X,A,"=",ES12.5)', 'aL', aL
+      print '("#",4X,A,"=",ES12.5)', 'ax', ax
+      print '("#",4X,A,"=",ES12.5)', 'ay', ay
+      print '("#",4X,A,"=",ES12.5)', 'az', az
+      print '("#",4X,A,"=",I1)', 'Sym', Sym
+      print '("#",4X,A,"=",A)', 'crystal_structure', crystal_structure
+      print '("#",4X,A,"=",I1)', 'NB', NB
+      print '("#",4X,A,"=",I1)', 'Nelec', Nelec
+      print '("#",4X,A,"=",A)', 'ext_field', ext_field
+      print '("#",4X,A,"=",A)', 'MD_option', MD_option
+      print '("#",4X,A,"=",A)', 'AD_RHO', AD_RHO
+      print '("#",4X,A,"=",I1)', 'NE', NE
+      print '("#",4X,A,"=",I1)', 'NI', NI
+      print '("#namelist: ",A,", status=",I1)', 'rgrid', inml_rgrid
+      print '("#",4X,A,"=",I1)', 'Nd', Nd
+      print '("#",4X,A,"=",I1)', 'NLx', NLx
+      print '("#",4X,A,"=",I1)', 'NLy', NLy
+      print '("#",4X,A,"=",I1)', 'NLz', NLz
+      print '("#namelist: ",A,", status=",I1)', 'kgrid', inml_kgrid
+      print '("#",4X,A,"=",I1)', 'NKx', NKx
+      print '("#",4X,A,"=",I1)', 'NKy', NKy
+      print '("#",4X,A,"=",I1)', 'NKz', NKz
+      print '("#",4X,A,"=",A)', 'file_kw', file_kw
+      print '("#namelist: ",A,", status=",I1)', 'tstep', inml_tstep
+      print '("#",4X,A,"=",I1)', 'Nt', Nt
+      print '("#",4X,A,"=",ES12.5)', 'dt', dt
+      print '("#namelist: ",A,", status=",I1)', 'pseudo', inml_pseudo
+      print '("#",4X,A,"=",A)', 'ps_format', ps_format
+      print '("#",4X,A,"=",A)', 'PSmask_option', PSmask_option
+      print '("#",4X,A,"=",ES12.5)', 'alpha_mask', alpha_mask
+      print '("#",4X,A,"=",ES12.5)', 'gamma_mask', gamma_mask
+      print '("#",4X,A,"=",ES12.5)', 'eta_mask', eta_mask
+      print '("#namelist: ",A,", status=",I1)', 'electrons', inml_electrons
+      print '("#",4X,A,"=",I1)', 'NEwald', NEwald
+      print '("#",4X,A,"=",ES12.5)', 'aEwald', aEwald
+      print '("#",4X,A,"=",ES12.5)', 'KbTev', KbTev
+      print '("#",4X,A,"=",I1)', 'Ncg', Ncg
+      print '("#",4X,A,"=",I1)', 'Nmemory_MB', Nmemory_MB
+      print '("#",4X,A,"=",ES12.5)', 'alpha_MB', alpha_MB
+      print '("#",4X,A,"=",A)', 'FSset_option', FSset_option
+      print '("#",4X,A,"=",I1)', 'NFSset_start', NFSset_start
+      print '("#",4X,A,"=",I1)', 'NFSset_every', NFSset_every
+      print '("#",4X,A,"=",I1)', 'Nscf', Nscf
+      print '("#namelist: ",A,", status=",I1)', 'incident', inml_incident
+      print '("#",4X,A,"=",A)', 'Longi_Trans', Longi_Trans
+      print '("#",4X,A,"=",ES12.5)', 'dAc', dAc
+      print '("#",4X,A,"=",A)', 'AE_shape', AE_shape
+      print '("#",4X,A,"=",ES12.5)', 'IWcm2_1', IWcm2_1
+      print '("#",4X,A,"=",ES12.5)', 'tpulsefs_1', tpulsefs_1
+      print '("#",4X,A,"=",ES12.5)', 'omegaev_1', omegaev_1
+      print '("#",4X,A,"=",ES12.5)', 'phi_CEP_1', phi_CEP_1
+      print '("#",4X,A,"=",ES12.5,",",ES12.5,",",ES12.5)', 'Epdir_1', Epdir_1
+      print '("#",4X,A,"=",ES12.5)', 'IWcm2_2', IWcm2_2
+      print '("#",4X,A,"=",ES12.5)', 'tpulsefs_2', tpulsefs_2
+      print '("#",4X,A,"=",ES12.5)', 'omegaev_2', omegaev_2
+      print '("#",4X,A,"=",ES12.5)', 'phi_CEP_2', phi_CEP_2
+      print '("#",4X,A,"=",ES12.5,",",ES12.5,",",ES12.5)', 'Epdir_2', Epdir_2
+      print '("#",4X,A,"=",ES12.5)', 'T1_T2fs', T1_T2fs
+      print '("#namelist: ",A,", status=",I1)', 'response', inml_response
+      print '("#",4X,A,"=",I1)', 'Nomega', Nomega
+      print '("#",4X,A,"=",ES12.5)', 'domega', domega
+      print '("#namelist: ",A,", status=",I1)', 'multiscale', inml_multiscale
+      print '("#",4X,A,"=",A)', 'FDTDdim', FDTDdim
+      print '("#",4X,A,"=",A)', 'TwoD_shape', TwoD_shape
+      print '("#",4X,A,"=",I1)', 'NX_m', NX_m
+      print '("#",4X,A,"=",I1)', 'NY_m', NY_m
+      print '("#",4X,A,"=",ES12.5)', 'HX_m', HX_m
+      print '("#",4X,A,"=",ES12.5)', 'HY_m', HY_m
+      print '("#",4X,A,"=",I1)', 'NKsplit', NKsplit
+      print '("#",4X,A,"=",I1)', 'NXYsplit', NXYsplit
+      print '("#",4X,A,"=",I1)', 'NXvacL_m', NXvacL_m
+      print '("#",4X,A,"=",I1)', 'NXvacR_m', NXvacR_m
+      
+      print *, "#section: atomic_positions"
+      do i=1, NE
+        print '("#",4X,I1,",Zatom=",I1,",Lref=",I1)', i, Zatom(i), Lref(i)
+      end do
+      
+      print *, "#section: atomic_positions"
+      do i=1, NI
+        print '("#",4X,I1,",Rion=",3ES12.5,",Kion=",I1)', i, Rion(:,i), Kion(i)
+      end do
+    end if
+    call comm_sync_all()
+    return
+  end subroutine dump_inputdata
+  
+  
+  
+end module inputfile

--- a/data/convert_ms.py
+++ b/data/convert_ms.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+#
+#   Copyright 2016 ARTED developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import sys
+from collections import deque
+
+input_list = [
+    "entrance_option", "Time_shutdown", "entrance_iter", "SYSname", 
+    "directory", "functional", "cval", "ps_format", "PSmask_option", 
+    "alpha_mask", "gamma_mask", "eta_mask", "aL", "ax", "ay", "az", "Sym", 
+    "crystal_structure", "Nd", "NLx", "NLy", "NLz", "NKx", "NKy", "NKz", 
+    "file_kw", "FDTDdim", "TwoD_shape", "NX_m", "NY_m", "HX_m", "HY_m", 
+    "NKsplit", "NXYsplit", "NXvacL_m", "NXvacR_m", "NEwald", "aEwald", 
+    "KbTev", "NB", "Nelec", "FSset_option", "Ncg", "Nmemory_MB", "alpha_MB", 
+    "NFSset_start", "NFSset_every", "Nscf", "MD_option", "AD_RHO", "Nt", "dt", 
+    "dAc", "Nomega", "domega", "AE_shape", "IWcm2_1", "tpulsefs_1", 
+    "omegaev_1", "phi_CEP_1", "Epdir_1", "IWcm2_2", "tpulsefs_2", "omegaev_2", 
+    "phi_CEP_2", "Epdir_2", "T1_T2fs", "NI", "NE", 
+]
+
+output_list = [
+    ["control", [
+        "entrance_option", "Time_shutdown", "entrance_iter", "SYSname", 
+        "directory", 
+    ]],
+    ["system", [
+        "functional", "cval", "aL", "ax", "ay", "az", "Sym", 
+        "crystal_structure", "NB", "Nelec", "ext_field", "MD_option", 
+        "AD_RHO", "NE", "NI", 
+    ]],
+    ["rgrid", [
+        "Nd", "NLx", "NLy", "NLz", 
+    ]],
+    ["kgrid", [
+        "NKx", "NKy", "NKz", "file_kw", 
+    ]],
+    ["tstep", [
+        "Nt", "dt", 
+    ]],
+    ["pseudo", [
+        "ps_format", "PSmask_option", "alpha_mask", "gamma_mask", "eta_mask", 
+    ]],
+    ["electrons", [
+        "NEwald", "aEwald", "KbTev", "Ncg", "Nmemory_MB", "alpha_MB", 
+        "FSset_option", "NFSset_start", "NFSset_every", "Nscf", 
+    ]],
+    ["incident", [
+        "Longi_Trans", "dAc", "AE_shape", "IWcm2_1", "tpulsefs_1", 
+        "omegaev_1", "phi_CEP_1", "Epdir_1", "IWcm2_2", "tpulsefs_2", 
+        "omegaev_2", "phi_CEP_2", "Epdir_2", "T1_T2fs", 
+    ]],
+    ["response", [
+        "Nomega", "domega", 
+    ]],
+    ["multiscale", [
+        "FDTDdim", "TwoD_shape", "NX_m", "NY_m", "HX_m", "HY_m", "NKsplit", 
+        "NXYsplit", "NXvacL_m", "NXvacR_m", 
+    ]],
+]
+
+print("'multiscale'")
+
+param_q = deque(input_list)
+
+buff = deque([])
+for line in sys.stdin:
+    temp = line.split("!")[0]
+    temp = temp.replace(",", " ")
+    buff += temp.split()
+
+data = {}
+while param_q:
+    param = param_q.popleft()
+    if param == "file_kw":
+        if 0 < int(data["NKx"]):
+            continue
+    elif param in ["Epdir_1", "Epdir_2"]:
+        data[param] = ",".join([buff.popleft() for i in xrange(3)])
+    else:
+        data[param] = buff.popleft()
+
+for group, param_list in output_list:
+    print("&%s" % group)
+    for param in param_list:
+        if param in data:
+            print("\t%s=%s" % (param, data[param]))
+    print("\t/")
+
+print("&atomic_spiecies")
+for i in range(int(data["NE"])):
+    temp = "\t".join([buff.popleft() for j in range(2)])
+    print("\t%d\t%s" % (i+1, temp))
+print("\t/")
+
+print("&atomic_positions")
+for i in range(int(data["NI"])):
+    temp = "\t".join([buff.popleft() for j in range(5)])
+    print("\t%s" % temp)
+print("\t/")

--- a/data/convert_sc.py
+++ b/data/convert_sc.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+#
+#   Copyright 2016 ARTED developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+import sys
+from collections import deque
+
+input_list = [
+    "entrance_option", "Time_shutdown", "entrance_iter", "SYSname", 
+    "directory", "functional", "cval", "ps_format", "PSmask_option", 
+    "alpha_mask", "gamma_mask", "eta_mask", "aL", "ax", "ay", "az", "Sym", 
+    "crystal_structure", "Nd", "NLx", "NLy", "NLz", "NKx", "NKy", "NKz", 
+    "file_kw", "NEwald", "aEwald", "KbTev", "NB", "Nelec", "FSset_option", 
+    "Ncg", "Nmemory_MB", "alpha_MB", "NFSset_start", "NFSset_every", "Nscf", 
+    "ext_field", "Longi_Trans", "MD_option", "AD_RHO", "Nt", "dt", "dAc", 
+    "Nomega", "domega", "AE_shape", "IWcm2_1", "tpulsefs_1", "omegaev_1", 
+    "phi_CEP_1", "Epdir_1", "IWcm2_2", "tpulsefs_2", "omegaev_2", "phi_CEP_2", 
+    "Epdir_2", "T1_T2fs", "NI", "NE",
+]
+
+output_list = [
+    ["control", [
+        "entrance_option", "Time_shutdown", "entrance_iter", "SYSname", 
+        "directory", 
+    ]],
+    ["system", [
+        "functional", "cval", "aL", "ax", "ay", "az", "Sym", 
+        "crystal_structure", "NB", "Nelec", "ext_field", "MD_option", 
+        "AD_RHO", "NE", "NI", 
+    ]],
+    ["rgrid", [
+        "Nd", "NLx", "NLy", "NLz", 
+    ]],
+    ["kgrid", [
+        "NKx", "NKy", "NKz", "file_kw", 
+    ]],
+    ["tstep", [
+        "Nt", "dt", 
+    ]],
+    ["pseudo", [
+        "ps_format", "PSmask_option", "alpha_mask", "gamma_mask", "eta_mask", 
+    ]],
+    ["electrons", [
+        "NEwald", "aEwald", "KbTev", "Ncg", "Nmemory_MB", "alpha_MB", 
+        "FSset_option", "NFSset_start", "NFSset_every", "Nscf", 
+    ]],
+    ["incident", [
+        "Longi_Trans", "dAc", "AE_shape", "IWcm2_1", "tpulsefs_1", 
+        "omegaev_1", "phi_CEP_1", "Epdir_1", "IWcm2_2", "tpulsefs_2", 
+        "omegaev_2", "phi_CEP_2", "Epdir_2", "T1_T2fs", 
+    ]],
+    ["response", [
+        "Nomega", "domega", 
+    ]],
+    ["multiscale", [
+        "FDTDdim", "TwoD_shape", "NX_m", "NY_m", "HX_m", "HY_m", "NKsplit", 
+        "NXYsplit", "NXvacL_m", "NXvacR_m", 
+    ]],
+]
+
+print("'singlecell'")
+
+param_q = deque(input_list)
+
+buff = deque([])
+for line in sys.stdin:
+    temp = line.split("!")[0]
+    temp = temp.replace(",", " ")
+    buff += temp.split()
+
+data = {}
+while param_q:
+    param = param_q.popleft()
+    if param == "file_kw":
+        if 0 < int(data["NKx"]):
+            continue
+    elif param in ["Epdir_1", "Epdir_2"]:
+        data[param] = ",".join([buff.popleft() for i in xrange(3)])
+    else:
+        data[param] = buff.popleft()
+
+for group, param_list in output_list:
+    print("&%s" % group)
+    for param in param_list:
+        if param in data:
+            print("\t%s=%s" % (param, data[param]))
+    print("\t/")
+
+print("&atomic_spiecies")
+for i in range(int(data["NE"])):
+    temp = "\t".join([buff.popleft() for j in range(2)])
+    print("\t%d\t%s" % (i+1, temp))
+print("\t/")
+
+print("&atomic_positions")
+for i in range(int(data["NI"])):
+    temp = "\t".join([buff.popleft() for j in range(5)])
+    print("\t%s" % temp)
+print("\t/")

--- a/data/input_ms.nml
+++ b/data/input_ms.nml
@@ -1,0 +1,102 @@
+'multiscale'
+&control
+	entrance_option='new'
+	Time_shutdown=1d10
+	entrance_iter=0
+	SYSname='Si'
+	directory='./data/'
+	/
+&system
+	functional='PZ'
+	cval=1.00d0
+	aL=10.26d0
+	ax=1.d0
+	ay=1.d0
+	az=1.d0
+	Sym=4
+	crystal_structure='diamond'
+	NB=32
+	Nelec=32
+	MD_option='N'
+	AD_RHO='No'
+	NE=1
+	NI=8
+	/
+&rgrid
+	Nd=4
+	NLx=12
+	NLy=12
+	NLz=12
+	/
+&kgrid
+	NKx=2
+	NKy=2
+	NKz=2
+	/
+&tstep
+	Nt=10000
+	dt=0.08
+	/
+&pseudo
+	ps_format='KY'
+	PSmask_option='n'
+	alpha_mask=0.8d0
+	gamma_mask=1.8d0
+	eta_mask=15.d0
+	/
+&electrons
+	NEwald=4
+	aEwald=0.5d0
+	KbTev=-1.0
+	Ncg=5
+	Nmemory_MB=8
+	alpha_MB=0.75
+	FSset_option='N'
+	NFSset_start=75
+	NFSset_every=25
+	Nscf=100
+	/
+&incident
+	dAc=0.005
+	AE_shape='Asin2cos'
+	IWcm2_1=1d14
+	tpulsefs_1=10.672
+	omegaev_1=1.55
+	phi_CEP_1=.0
+	Epdir_1=0.,0.,1.
+	IWcm2_2=0d11
+	tpulsefs_2=16.0
+	omegaev_2=1.55
+	phi_CEP_2=.0
+	Epdir_2=0.,0.,1.
+	T1_T2fs=19.0
+	/
+&response
+	Nomega=2000
+	domega=0.001
+	/
+&multiscale
+	FDTDdim='1D'
+	TwoD_shape='periodic'
+	NX_m=8
+	NY_m=1
+	HX_m=250
+	HY_m=2500
+	NKsplit=2
+	NXYsplit=1
+	NXvacL_m=-2000
+	NXvacR_m=256
+	/
+&atomic_spiecies
+	1	14	2
+	/
+&atomic_positions
+	1	.0	.0	.0	1
+	2	.25	.25	.25	1
+	3	.5	.0	.5	1
+	4	.0	.5	.5	1
+	5	.5	.5	.0	1
+	6	.75	.25	.75	1
+	7	.25	.75	.75	1
+	8	.75	.75	.25	1
+	/

--- a/data/input_ms_Si.cpu.nml
+++ b/data/input_ms_Si.cpu.nml
@@ -1,0 +1,102 @@
+'multiscale'
+&control
+	entrance_option='new'
+	Time_shutdown=1d10
+	entrance_iter=0
+	SYSname='Si'
+	directory='./data/'
+	/
+&system
+	functional='PZ'
+	cval=1.00d0
+	aL=10.26d0
+	ax=1.d0
+	ay=1.d0
+	az=1.d0
+	Sym=8
+	crystal_structure='diamond'
+	NB=32
+	Nelec=32
+	MD_option='N'
+	AD_RHO='No'
+	NE=1
+	NI=8
+	/
+&rgrid
+	Nd=4
+	NLx=16
+	NLy=16
+	NLz=16
+	/
+&kgrid
+	NKx=24
+	NKy=24
+	NKz=24
+	/
+&tstep
+	Nt=100
+	dt=0.08
+	/
+&pseudo
+	ps_format='KY'
+	PSmask_option='n'
+	alpha_mask=0.8d0
+	gamma_mask=1.8d0
+	eta_mask=15.d0
+	/
+&electrons
+	NEwald=4
+	aEwald=0.5d0
+	KbTev=-1.0
+	Ncg=1
+	Nmemory_MB=8
+	alpha_MB=0.75
+	FSset_option='N'
+	NFSset_start=75
+	NFSset_every=25
+	Nscf=1
+	/
+&incident
+	dAc=0.005
+	AE_shape='Asin2cos'
+	IWcm2_1=1d12
+	tpulsefs_1=10.672
+	omegaev_1=1.55
+	phi_CEP_1=.0
+	Epdir_1=0.,0.,1.
+	IWcm2_2=0d11
+	tpulsefs_2=16.0
+	omegaev_2=1.55
+	phi_CEP_2=.0
+	Epdir_2=0.,0.,1.
+	T1_T2fs=19.0
+	/
+&response
+	Nomega=2000
+	domega=0.001
+	/
+&multiscale
+	FDTDdim='1D'
+	TwoD_shape='periodic'
+	NX_m=0
+	NY_m=1
+	HX_m=250
+	HY_m=2500
+	NKsplit=4
+	NXYsplit=1
+	NXvacL_m=-2000
+	NXvacR_m=256
+	/
+&atomic_spiecies
+	1	14	2
+	/
+&atomic_positions
+	1	.0	.0	.0	1
+	2	.25	.25	.25	1
+	3	.5	.0	.5	1
+	4	.0	.5	.5	1
+	5	.5	.5	.0	1
+	6	.75	.25	.75	1
+	7	.25	.75	.75	1
+	8	.75	.75	.25	1
+	/

--- a/data/input_ms_Si.nml
+++ b/data/input_ms_Si.nml
@@ -1,0 +1,102 @@
+'multiscale'
+&control
+	entrance_option='new'
+	Time_shutdown=1d10
+	entrance_iter=0
+	SYSname='Si'
+	directory='./data/'
+	/
+&system
+	functional='PZ'
+	cval=1.00d0
+	aL=10.26d0
+	ax=1.d0
+	ay=1.d0
+	az=1.d0
+	Sym=8
+	crystal_structure='diamond'
+	NB=32
+	Nelec=32
+	MD_option='N'
+	AD_RHO='No'
+	NE=1
+	NI=8
+	/
+&rgrid
+	Nd=4
+	NLx=16
+	NLy=16
+	NLz=16
+	/
+&kgrid
+	NKx=24
+	NKy=24
+	NKz=24
+	/
+&tstep
+	Nt=100
+	dt=0.08
+	/
+&pseudo
+	ps_format='KY'
+	PSmask_option='n'
+	alpha_mask=0.8d0
+	gamma_mask=1.8d0
+	eta_mask=15.d0
+	/
+&electrons
+	NEwald=4
+	aEwald=0.5d0
+	KbTev=-1.0
+	Ncg=1
+	Nmemory_MB=8
+	alpha_MB=0.75
+	FSset_option='N'
+	NFSset_start=75
+	NFSset_every=25
+	Nscf=1
+	/
+&incident
+	dAc=0.005
+	AE_shape='Asin2cos'
+	IWcm2_1=1d12
+	tpulsefs_1=10.672
+	omegaev_1=1.55
+	phi_CEP_1=.0
+	Epdir_1=0.,0.,1.
+	IWcm2_2=0d11
+	tpulsefs_2=16.0
+	omegaev_2=1.55
+	phi_CEP_2=.0
+	Epdir_2=0.,0.,1.
+	T1_T2fs=19.0
+	/
+&response
+	Nomega=2000
+	domega=0.001
+	/
+&multiscale
+	FDTDdim='1D'
+	TwoD_shape='periodic'
+	NX_m=2
+	NY_m=1
+	HX_m=250
+	HY_m=2500
+	NKsplit=4
+	NXYsplit=1
+	NXvacL_m=-2000
+	NXvacR_m=256
+	/
+&atomic_spiecies
+	1	14	2
+	/
+&atomic_positions
+	1	.0	.0	.0	1
+	2	.25	.25	.25	1
+	3	.5	.0	.5	1
+	4	.0	.5	.5	1
+	5	.5	.5	.0	1
+	6	.75	.25	.75	1
+	7	.25	.75	.75	1
+	8	.75	.75	.25	1
+	/

--- a/data/input_ms_Si.sym.nml
+++ b/data/input_ms_Si.sym.nml
@@ -1,0 +1,102 @@
+'multiscale'
+&control
+	entrance_option='new'
+	Time_shutdown=1d10
+	entrance_iter=0
+	SYSname='Si'
+	directory='./data/'
+	/
+&system
+	functional='PZ'
+	cval=1.00d0
+	aL=10.26d0
+	ax=1.d0
+	ay=1.d0
+	az=1.d0
+	Sym=8
+	crystal_structure='diamond'
+	NB=32
+	Nelec=32
+	MD_option='N'
+	AD_RHO='No'
+	NE=1
+	NI=8
+	/
+&rgrid
+	Nd=4
+	NLx=16
+	NLy=16
+	NLz=16
+	/
+&kgrid
+	NKx=24
+	NKy=24
+	NKz=24
+	/
+&tstep
+	Nt=100
+	dt=0.08
+	/
+&pseudo
+	ps_format='KY'
+	PSmask_option='n'
+	alpha_mask=0.8d0
+	gamma_mask=1.8d0
+	eta_mask=15.d0
+	/
+&electrons
+	NEwald=4
+	aEwald=0.5d0
+	KbTev=-1.0
+	Ncg=1
+	Nmemory_MB=8
+	alpha_MB=0.75
+	FSset_option='N'
+	NFSset_start=75
+	NFSset_every=25
+	Nscf=1
+	/
+&incident
+	dAc=0.005
+	AE_shape='Asin2cos'
+	IWcm2_1=1d12
+	tpulsefs_1=10.672
+	omegaev_1=1.55
+	phi_CEP_1=.0
+	Epdir_1=0.,0.,1.
+	IWcm2_2=0d11
+	tpulsefs_2=16.0
+	omegaev_2=1.55
+	phi_CEP_2=.0
+	Epdir_2=0.,0.,1.
+	T1_T2fs=19.0
+	/
+&response
+	Nomega=2000
+	domega=0.001
+	/
+&multiscale
+	FDTDdim='1D'
+	TwoD_shape='periodic'
+	NX_m=0
+	NY_m=1
+	HX_m=250
+	HY_m=2500
+	NKsplit=8
+	NXYsplit=1
+	NXvacL_m=-2000
+	NXvacR_m=256
+	/
+&atomic_spiecies
+	1	14	2
+	/
+&atomic_positions
+	1	.0	.0	.0	1
+	2	.25	.25	.25	1
+	3	.5	.0	.5	1
+	4	.0	.5	.5	1
+	5	.5	.5	.0	1
+	6	.75	.25	.75	1
+	7	.25	.75	.75	1
+	8	.75	.75	.25	1
+	/

--- a/data/input_ms_Si.verify.nml
+++ b/data/input_ms_Si.verify.nml
@@ -1,0 +1,102 @@
+'multiscale'
+&control
+	entrance_option='new'
+	Time_shutdown=1d10
+	entrance_iter=0
+	SYSname='Si'
+	directory='./data/'
+	/
+&system
+	functional='PZ'
+	cval=1.00d0
+	aL=10.26d0
+	ax=1.d0
+	ay=1.d0
+	az=1.d0
+	Sym=8
+	crystal_structure='diamond'
+	NB=32
+	Nelec=32
+	MD_option='N'
+	AD_RHO='No'
+	NE=1
+	NI=8
+	/
+&rgrid
+	Nd=4
+	NLx=16
+	NLy=16
+	NLz=16
+	/
+&kgrid
+	NKx=24
+	NKy=24
+	NKz=24
+	/
+&tstep
+	Nt=1000
+	dt=0.08
+	/
+&pseudo
+	ps_format='KY'
+	PSmask_option='n'
+	alpha_mask=0.8d0
+	gamma_mask=1.8d0
+	eta_mask=15.d0
+	/
+&electrons
+	NEwald=4
+	aEwald=0.5d0
+	KbTev=-1.0
+	Ncg=5
+	Nmemory_MB=8
+	alpha_MB=0.75
+	FSset_option='N'
+	NFSset_start=75
+	NFSset_every=25
+	Nscf=100
+	/
+&incident
+	dAc=0.005
+	AE_shape='Asin2cos'
+	IWcm2_1=1d12
+	tpulsefs_1=10.672
+	omegaev_1=1.55
+	phi_CEP_1=.0
+	Epdir_1=0.,0.,1.
+	IWcm2_2=0d11
+	tpulsefs_2=16.0
+	omegaev_2=1.55
+	phi_CEP_2=.0
+	Epdir_2=0.,0.,1.
+	T1_T2fs=19.0
+	/
+&response
+	Nomega=2000
+	domega=0.001
+	/
+&multiscale
+	FDTDdim='1D'
+	TwoD_shape='periodic'
+	NX_m=0
+	NY_m=1
+	HX_m=250
+	HY_m=2500
+	NKsplit=4
+	NXYsplit=1
+	NXvacL_m=-2000
+	NXvacR_m=256
+	/
+&atomic_spiecies
+	1	14	2
+	/
+&atomic_positions
+	1	.0	.0	.0	1
+	2	.25	.25	.25	1
+	3	.5	.0	.5	1
+	4	.0	.5	.5	1
+	5	.5	.5	.0	1
+	6	.75	.25	.75	1
+	7	.25	.75	.75	1
+	8	.75	.75	.25	1
+	/

--- a/data/input_ms_Si_small.nml
+++ b/data/input_ms_Si_small.nml
@@ -1,0 +1,102 @@
+'multiscale'
+&control
+	entrance_option='new'
+	Time_shutdown=1d10
+	entrance_iter=0
+	SYSname='Si'
+	directory='./data/'
+	/
+&system
+	functional='PZ'
+	cval=1.00d0
+	aL=10.26d0
+	ax=1.d0
+	ay=1.d0
+	az=1.d0
+	Sym=8
+	crystal_structure='diamond'
+	NB=32
+	Nelec=32
+	MD_option='N'
+	AD_RHO='No'
+	NE=1
+	NI=8
+	/
+&rgrid
+	Nd=4
+	NLx=16
+	NLy=16
+	NLz=16
+	/
+&kgrid
+	NKx=12
+	NKy=12
+	NKz=12
+	/
+&tstep
+	Nt=100
+	dt=0.08
+	/
+&pseudo
+	ps_format='KY'
+	PSmask_option='n'
+	alpha_mask=0.8d0
+	gamma_mask=1.8d0
+	eta_mask=15.d0
+	/
+&electrons
+	NEwald=4
+	aEwald=0.5d0
+	KbTev=-1.0
+	Ncg=1
+	Nmemory_MB=8
+	alpha_MB=0.75
+	FSset_option='N'
+	NFSset_start=75
+	NFSset_every=25
+	Nscf=1
+	/
+&incident
+	dAc=0.005
+	AE_shape='Asin2cos'
+	IWcm2_1=1d12
+	tpulsefs_1=10.672
+	omegaev_1=1.55
+	phi_CEP_1=.0
+	Epdir_1=0.,0.,1.
+	IWcm2_2=0d11
+	tpulsefs_2=16.0
+	omegaev_2=1.55
+	phi_CEP_2=.0
+	Epdir_2=0.,0.,1.
+	T1_T2fs=19.0
+	/
+&response
+	Nomega=2000
+	domega=0.001
+	/
+&multiscale
+	FDTDdim='1D'
+	TwoD_shape='periodic'
+	NX_m=2
+	NY_m=1
+	HX_m=250
+	HY_m=2500
+	NKsplit=2
+	NXYsplit=1
+	NXvacL_m=-2000
+	NXvacR_m=256
+	/
+&atomic_spiecies
+	1	14	2
+	/
+&atomic_positions
+	1	.0	.0	.0	1
+	2	.25	.25	.25	1
+	3	.5	.0	.5	1
+	4	.0	.5	.5	1
+	5	.5	.5	.0	1
+	6	.75	.25	.75	1
+	7	.25	.75	.75	1
+	8	.75	.75	.25	1
+	/

--- a/data/input_sc.nml
+++ b/data/input_sc.nml
@@ -1,0 +1,105 @@
+'singlecell'
+&control
+	entrance_option='new'
+	Time_shutdown=1d10
+	entrance_iter=0
+	SYSname='SiO2'
+	directory='./data/'
+	/
+&system
+	functional='PZ'
+	cval=1.00d0
+	aL=9.2849d0
+	ax=1.d0
+	ay=1.732051d0
+	az=1.100094d0
+	Sym=1
+	crystal_structure='diamond'
+	NB=52
+	Nelec=96
+	ext_field='LF'
+	MD_option='N'
+	AD_RHO='No'
+	NE=2
+	NI=18
+	/
+&rgrid
+	Nd=4
+	NLx=20
+	NLy=36
+	NLz=52
+	/
+&kgrid
+	NKx=4
+	NKy=4
+	NKz=4
+	/
+&tstep
+	Nt=50
+	dt=0.04
+	/
+&pseudo
+	ps_format='KY'
+	PSmask_option='n'
+	alpha_mask=0.8d0
+	gamma_mask=1.8d0
+	eta_mask=15.d0
+	/
+&electrons
+	NEwald=4
+	aEwald=0.5d0
+	KbTev=-1.0
+	Ncg=1
+	Nmemory_MB=8
+	alpha_MB=0.75
+	FSset_option='N'
+	NFSset_start=75
+	NFSset_every=25
+	Nscf=1
+	/
+&incident
+	Longi_Trans='Tr'
+	dAc=0.005
+	AE_shape='Asin2cos'
+	IWcm2_1=1d14
+	tpulsefs_1=10.672
+	omegaev_1=1.55
+	phi_CEP_1=.0
+	Epdir_1=0.,0.,1.
+	IWcm2_2=0d11
+	tpulsefs_2=16.0
+	omegaev_2=1.55
+	phi_CEP_2=.0
+	Epdir_2=0.,0.,1.
+	T1_T2fs=19.0
+	/
+&response
+	Nomega=2000
+	domega=0.001
+	/
+&multiscale
+	/
+&atomic_spiecies
+	1	14	8
+	2	2	1
+	/
+&atomic_positions
+	1	.9701	.5000	.0000	1
+	2	.2649	.7350	.6667	1
+	3	.2649	.2650	.3333	1
+	4	.7798	.6338	.1191	2
+	5	.5608	.7068	.5476	2
+	6	.1594	.5730	.7858	2
+	7	.1594	.4270	.2142	2
+	8	.5608	.2932	.4524	2
+	9	.7798	.3662	.8809	2
+	10	.4701	.0000	.0000	1
+	11	.7649	.2350	.6667	1
+	12	.7649	.7650	.3333	1
+	13	.2798	.1338	.1191	2
+	14	.0608	.2068	.5476	2
+	15	.6594	.0730	.7858	2
+	16	.6594	.9270	.2142	2
+	17	.0608	.7932	.4524	2
+	18	.2798	.8662	.8809	2
+	/

--- a/data/input_sc_Si.nml
+++ b/data/input_sc_Si.nml
@@ -1,0 +1,94 @@
+'singlecell'
+&control
+	entrance_option='new'
+	Time_shutdown=1d10
+	entrance_iter=0
+	SYSname='Si'
+	directory='./data/'
+	/
+&system
+	functional='PZ'
+	cval=1.00d0
+	aL=10.26d0
+	ax=1.d0
+	ay=1.d0
+	az=1.d0
+	Sym=1
+	crystal_structure='diamond'
+	NB=32
+	Nelec=32
+	ext_field='LF'
+	MD_option='N'
+	AD_RHO='No'
+	NE=1
+	NI=8
+	/
+&rgrid
+	Nd=4
+	NLx=16
+	NLy=16
+	NLz=16
+	/
+&kgrid
+	NKx=24
+	NKy=24
+	NKz=24
+	/
+&tstep
+	Nt=50
+	dt=0.04
+	/
+&pseudo
+	ps_format='KY'
+	PSmask_option='n'
+	alpha_mask=0.8d0
+	gamma_mask=1.8d0
+	eta_mask=15.d0
+	/
+&electrons
+	NEwald=4
+	aEwald=0.5d0
+	KbTev=-1.0
+	Ncg=1
+	Nmemory_MB=8
+	alpha_MB=0.75
+	FSset_option='N'
+	NFSset_start=75
+	NFSset_every=25
+	Nscf=1
+	/
+&incident
+	Longi_Trans='Tr'
+	dAc=0.005
+	AE_shape='Asin2cos'
+	IWcm2_1=1d14
+	tpulsefs_1=10.672
+	omegaev_1=1.55
+	phi_CEP_1=.0
+	Epdir_1=0.,0.,1.
+	IWcm2_2=0d11
+	tpulsefs_2=16.0
+	omegaev_2=1.55
+	phi_CEP_2=.0
+	Epdir_2=0.,0.,1.
+	T1_T2fs=19.0
+	/
+&response
+	Nomega=2000
+	domega=0.001
+	/
+&multiscale
+	/
+&atomic_spiecies
+	1	14	2
+	/
+&atomic_positions
+	1	.0	.0	.0	1
+	2	.25	.25	.25	1
+	3	.5	.0	.5	1
+	4	.0	.5	.5	1
+	5	.5	.5	.0	1
+	6	.75	.25	.75	1
+	7	.25	.75	.75	1
+	8	.75	.75	.25	1
+	/

--- a/data/input_sc_Si.single.nml
+++ b/data/input_sc_Si.single.nml
@@ -1,0 +1,94 @@
+'singlecell'
+&control
+	entrance_option='new'
+	Time_shutdown=1d10
+	entrance_iter=0
+	SYSname='Si'
+	directory='./data/'
+	/
+&system
+	functional='PZ'
+	cval=1.00d0
+	aL=10.26d0
+	ax=1.d0
+	ay=1.d0
+	az=1.d0
+	Sym=1
+	crystal_structure='diamond'
+	NB=32
+	Nelec=32
+	ext_field='LF'
+	MD_option='N'
+	AD_RHO='No'
+	NE=1
+	NI=8
+	/
+&rgrid
+	Nd=4
+	NLx=16
+	NLy=16
+	NLz=16
+	/
+&kgrid
+	NKx=16
+	NKy=8
+	NKz=8
+	/
+&tstep
+	Nt=50
+	dt=0.04
+	/
+&pseudo
+	ps_format='KY'
+	PSmask_option='n'
+	alpha_mask=0.8d0
+	gamma_mask=1.8d0
+	eta_mask=15.d0
+	/
+&electrons
+	NEwald=4
+	aEwald=0.5d0
+	KbTev=-1.0
+	Ncg=1
+	Nmemory_MB=8
+	alpha_MB=0.75
+	FSset_option='N'
+	NFSset_start=75
+	NFSset_every=25
+	Nscf=1
+	/
+&incident
+	Longi_Trans='Tr'
+	dAc=0.005
+	AE_shape='Asin2cos'
+	IWcm2_1=1d14
+	tpulsefs_1=10.672
+	omegaev_1=1.55
+	phi_CEP_1=.0
+	Epdir_1=0.,0.,1.
+	IWcm2_2=0d11
+	tpulsefs_2=16.0
+	omegaev_2=1.55
+	phi_CEP_2=.0
+	Epdir_2=0.,0.,1.
+	T1_T2fs=19.0
+	/
+&response
+	Nomega=2000
+	domega=0.001
+	/
+&multiscale
+	/
+&atomic_spiecies
+	1	14	2
+	/
+&atomic_positions
+	1	.0	.0	.0	1
+	2	.25	.25	.25	1
+	3	.5	.0	.5	1
+	4	.0	.5	.5	1
+	5	.5	.5	.0	1
+	6	.75	.25	.75	1
+	7	.25	.75	.75	1
+	8	.75	.75	.25	1
+	/

--- a/data/input_sc_Si.verify.nml
+++ b/data/input_sc_Si.verify.nml
@@ -1,0 +1,94 @@
+'singlecell'
+&control
+	entrance_option='new'
+	Time_shutdown=1d10
+	entrance_iter=0
+	SYSname='Si'
+	directory='./data/'
+	/
+&system
+	functional='PZ'
+	cval=1.00d0
+	aL=10.26d0
+	ax=1.d0
+	ay=1.d0
+	az=1.d0
+	Sym=8
+	crystal_structure='diamond'
+	NB=32
+	Nelec=32
+	ext_field='LR'
+	MD_option='N'
+	AD_RHO='No'
+	NE=1
+	NI=8
+	/
+&rgrid
+	Nd=4
+	NLx=16
+	NLy=16
+	NLz=16
+	/
+&kgrid
+	NKx=24
+	NKy=24
+	NKz=24
+	/
+&tstep
+	Nt=500
+	dt=0.16
+	/
+&pseudo
+	ps_format='KY'
+	PSmask_option='n'
+	alpha_mask=0.8d0
+	gamma_mask=1.8d0
+	eta_mask=15.d0
+	/
+&electrons
+	NEwald=4
+	aEwald=0.5d0
+	KbTev=-1.0
+	Ncg=5
+	Nmemory_MB=8
+	alpha_MB=0.75
+	FSset_option='N'
+	NFSset_start=75
+	NFSset_every=25
+	Nscf=100
+	/
+&incident
+	Longi_Trans='Tr'
+	dAc=0.005
+	AE_shape='Asin2cos'
+	IWcm2_1=1d14
+	tpulsefs_1=10.672
+	omegaev_1=1.55
+	phi_CEP_1=.0
+	Epdir_1=0.,0.,1.
+	IWcm2_2=0d11
+	tpulsefs_2=16.0
+	omegaev_2=1.55
+	phi_CEP_2=.0
+	Epdir_2=0.,0.,1.
+	T1_T2fs=19.0
+	/
+&response
+	Nomega=2000
+	domega=0.001
+	/
+&multiscale
+	/
+&atomic_spiecies
+	1	14	2
+	/
+&atomic_positions
+	1	.0	.0	.0	1
+	2	.25	.25	.25	1
+	3	.5	.0	.5	1
+	4	.0	.5	.5	1
+	5	.5	.5	.0	1
+	6	.75	.25	.75	1
+	7	.25	.75	.75	1
+	8	.75	.75	.25	1
+	/

--- a/data/input_sc_SiO2.nml
+++ b/data/input_sc_SiO2.nml
@@ -1,0 +1,105 @@
+'singlecell'
+&control
+	entrance_option='new'
+	Time_shutdown=1d10
+	entrance_iter=0
+	SYSname='SiO2'
+	directory='./data/'
+	/
+&system
+	functional='PZ'
+	cval=1.00d0
+	aL=9.2849d0
+	ax=1.d0
+	ay=1.732051d0
+	az=1.100094d0
+	Sym=1
+	crystal_structure='diamond'
+	NB=52
+	Nelec=96
+	ext_field='LR'
+	MD_option='N'
+	AD_RHO='No'
+	NE=2
+	NI=18
+	/
+&rgrid
+	Nd=4
+	NLx=20
+	NLy=36
+	NLz=52
+	/
+&kgrid
+	NKx=4
+	NKy=4
+	NKz=4
+	/
+&tstep
+	Nt=25000
+	dt=0.04
+	/
+&pseudo
+	ps_format='KY'
+	PSmask_option='n'
+	alpha_mask=0.8d0
+	gamma_mask=1.8d0
+	eta_mask=15.d0
+	/
+&electrons
+	NEwald=4
+	aEwald=0.5d0
+	KbTev=-1.0
+	Ncg=5
+	Nmemory_MB=8
+	alpha_MB=0.75
+	FSset_option='N'
+	NFSset_start=75
+	NFSset_every=25
+	Nscf=120
+	/
+&incident
+	Longi_Trans='Tr'
+	dAc=0.005
+	AE_shape='Asin2cos'
+	IWcm2_1=1d14
+	tpulsefs_1=10.672
+	omegaev_1=1.55
+	phi_CEP_1=.0
+	Epdir_1=0.,0.,1.
+	IWcm2_2=0d11
+	tpulsefs_2=16.0
+	omegaev_2=1.55
+	phi_CEP_2=.0
+	Epdir_2=0.,0.,1.
+	T1_T2fs=19.0
+	/
+&response
+	Nomega=2000
+	domega=0.001
+	/
+&multiscale
+	/
+&atomic_spiecies
+	1	14	8
+	2	2	1
+	/
+&atomic_positions
+	1	.9701	.5000	.0000	1
+	2	.2649	.7350	.6667	1
+	3	.2649	.2650	.3333	1
+	4	.7798	.6338	.1191	2
+	5	.5608	.7068	.5476	2
+	6	.1594	.5730	.7858	2
+	7	.1594	.4270	.2142	2
+	8	.5608	.2932	.4524	2
+	9	.7798	.3662	.8809	2
+	10	.4701	.0000	.0000	1
+	11	.7649	.2350	.6667	1
+	12	.7649	.7650	.3333	1
+	13	.2798	.1338	.1191	2
+	14	.0608	.2068	.5476	2
+	15	.6594	.0730	.7858	2
+	16	.6594	.9270	.2142	2
+	17	.0608	.7932	.4524	2
+	18	.2798	.8662	.8809	2
+	/

--- a/data/input_sc_Si_small.nml
+++ b/data/input_sc_Si_small.nml
@@ -1,0 +1,94 @@
+'singlecell'
+&control
+	entrance_option='new'
+	Time_shutdown=1d10
+	entrance_iter=0
+	SYSname='Si'
+	directory='./data/'
+	/
+&system
+	functional='PZ'
+	cval=1.00d0
+	aL=10.26d0
+	ax=1.d0
+	ay=1.d0
+	az=1.d0
+	Sym=8
+	crystal_structure='diamond'
+	NB=32
+	Nelec=32
+	ext_field='LF'
+	MD_option='N'
+	AD_RHO='No'
+	NE=1
+	NI=8
+	/
+&rgrid
+	Nd=4
+	NLx=16
+	NLy=16
+	NLz=16
+	/
+&kgrid
+	NKx=24
+	NKy=24
+	NKz=24
+	/
+&tstep
+	Nt=50
+	dt=0.04
+	/
+&pseudo
+	ps_format='KY'
+	PSmask_option='n'
+	alpha_mask=0.8d0
+	gamma_mask=1.8d0
+	eta_mask=15.d0
+	/
+&electrons
+	NEwald=4
+	aEwald=0.5d0
+	KbTev=-1.0
+	Ncg=1
+	Nmemory_MB=8
+	alpha_MB=0.75
+	FSset_option='N'
+	NFSset_start=75
+	NFSset_every=25
+	Nscf=1
+	/
+&incident
+	Longi_Trans='Tr'
+	dAc=0.005
+	AE_shape='Asin2cos'
+	IWcm2_1=1d14
+	tpulsefs_1=10.672
+	omegaev_1=1.55
+	phi_CEP_1=.0
+	Epdir_1=0.,0.,1.
+	IWcm2_2=0d11
+	tpulsefs_2=16.0
+	omegaev_2=1.55
+	phi_CEP_2=.0
+	Epdir_2=0.,0.,1.
+	T1_T2fs=19.0
+	/
+&response
+	Nomega=2000
+	domega=0.001
+	/
+&multiscale
+	/
+&atomic_spiecies
+	1	14	2
+	/
+&atomic_positions
+	1	.0	.0	.0	1
+	2	.25	.25	.25	1
+	3	.5	.0	.5	1
+	4	.0	.5	.5	1
+	5	.5	.5	.0	1
+	6	.75	.25	.75	1
+	7	.25	.75	.75	1
+	8	.75	.75	.25	1
+	/

--- a/data/input_sc_diamond2.nml
+++ b/data/input_sc_diamond2.nml
@@ -1,0 +1,90 @@
+'singlecell'
+&control
+	entrance_option='new'
+	Time_shutdown=7d3
+	entrance_iter=0
+	SYSname='diamond'
+	directory='./'
+	/
+&system
+	functional='TBmBJ'
+	cval=1.28d0
+	aL=6.74d0
+	ax=0.70710678d0
+	ay=0.70710678d0
+	az=1.d0
+	Sym=8
+	crystal_structure='diamond2'
+	NB=16
+	Nelec=16
+	ext_field='LF'
+	MD_option='N'
+	AD_RHO='No'
+	NE=1
+	NI=4
+	/
+&rgrid
+	Nd=4
+	NLx=16
+	NLy=16
+	NLz=20
+	/
+&kgrid
+	NKx=20
+	NKy=20
+	NKz=16
+	/
+&tstep
+	Nt=37500
+	dt=0.04
+	/
+&pseudo
+	ps_format='KY'
+	PSmask_option='n'
+	alpha_mask=0.8d0
+	gamma_mask=1.8d0
+	eta_mask=15.d0
+	/
+&electrons
+	NEwald=4
+	aEwald=0.5d0
+	KbTev=-1.0
+	Ncg=5
+	Nmemory_MB=8
+	alpha_MB=0.75
+	FSset_option='N'
+	NFSset_start=75
+	NFSset_every=25
+	Nscf=150
+	/
+&incident
+	Longi_Trans='Tr'
+	dAc=0.001879483
+	AE_shape='input'
+	IWcm2_1=1d14
+	tpulsefs_1=10.672
+	omegaev_1=1.55
+	phi_CEP_1=.0
+	Epdir_1=0.,0.,1.
+	IWcm2_2=0d11
+	tpulsefs_2=16.0
+	omegaev_2=1.55
+	phi_CEP_2=.0
+	Epdir_2=0.,0.,1.
+	T1_T2fs=19.0
+	/
+&response
+	Nomega=2000
+	domega=0.001
+	/
+&multiscale
+	/
+&atomic_spiecies
+	1	6	1
+	/
+&atomic_positions
+	1	.0	.0	.0	1
+	2	.0	.5	.25	1
+	3	.5	.0	.75	1
+	4	.5	.5	.5	1
+	/

--- a/main.f90
+++ b/main.f90
@@ -41,12 +41,17 @@ Program main
                             & proc_group              
   use control_sc,       only: main_sc => main
   use control_ms,       only: main_ms => main
+  use inputfile,        only: read_input, &
+                            & dump_inputdata
   implicit none
   
   call comm_init()
   if (comm_is_root()) read(*,*) calc_mode
   call comm_bcast_character(calc_mode, proc_group(1))
   
+  call read_input
+  !call dump_inputdata
+
   select case(calc_mode)
   case (calc_mode_sc)
     call main_sc


### PR DESCRIPTION
This PR provides the new inputfile reader, which makes possible to use the namelist based input file format. 
- Add inputfile module `control/inputfile.f90` for the namelist
- Add inputfile converter script `data/convert_(sc|ms).py` to convert the previous inputfiles to new namelist format.

    python convert_sc.py < input_Si_sc.dat > input_Si_sc.nml

- Add converted examples  as `data/*.nml` from `data/*.dat`
- Tested new inputfiles successfully reproduces the previous calculation.

__NOTES__
- Please be careful for compatibility of inputfile.