### PR TITLE
Fixed a problem for an output of ms calc.

### DIFF
--- a/main/ms.f90
+++ b/main/ms.f90
@@ -488,8 +488,8 @@ Program main
 
       if(comm_is_root(1))then
         call write_result(index)
-!        write(940,'(4e26.16E3)')iter*dt,sum(energy_elec)*HX_m*HY_m/aLxyz &
-!          &,sum(energy_elemag)*HX_m*HY_m/aLxyz,sum(energy_total)*HX_m*HY_m/aLxyz
+        write(940,'(4e26.16E3)')iter*dt,sum(energy_elec)*HX_m*HY_m/aLxyz &
+          &,sum(energy_elemag)*HX_m*HY_m/aLxyz,sum(energy_total)*HX_m*HY_m/aLxyz
       end if
     end if
     call timelog_end(LOG_OTHER)


### PR DESCRIPTION
After the pull request #64, an output file of `ms` calculation, `energy-transfer.out`, became empty. I made it write the data again.