### PR TITLE
Modification for compatibility to SALMON-TDDFT

### DIFF
--- a/control/control_ms.f90
+++ b/control/control_ms.f90
@@ -39,7 +39,9 @@ subroutine main
   call load_environments
 
   if(comm_is_root(1)) then
-    write(*,'(2A)')'ARTED ver. = ',ARTED_ver
+    write(*,'(A)') "Welcome to SALMON-TDDFT multiscale mode"
+    write(*,'(A)') "(Preliminary Developers Version)"
+    write(*,'(2A)') "based on ARTED ver. = ",ARTED_ver
     call print_optimize_message
   end if
 

--- a/control/control_sc.f90
+++ b/control/control_sc.f90
@@ -37,7 +37,9 @@ subroutine main
   call load_environments
 
   if(comm_is_root()) then
-    write(*,'(2A)')'ARTED ver. = ',ARTED_ver
+    write(*,'(A)') "Welcome to SALMON-TDDFT singlecell mode"
+    write(*,'(A)') "(Preliminary Developers Version)"
+    write(*,'(2A)') "based on ARTED ver. = ",ARTED_ver
     call print_optimize_message
   end if
 


### PR DESCRIPTION
- This modification `control_(sc|ms).f90`  reduce the differences between `dev_salmon` and `SALMON-TDDFT/develop`