### PR TITLE
Add input parameter for propagation scheme.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,6 @@ option_set(ENABLE_SWPREFETCH              "Enable software prefetch in the expli
 option_set(ENABLE_REDUCE_FOR_MANYCORE     "Enable optimized reduction code for many-core processor"  OFF)
 option_set(ENABLE_OPENACC                 "Enable OpenACC for NVIDIA GPUs"                           OFF)
 option_set(ENABLE_LARGE_BLOCKING          "Enable large blocking for accelerator"                    OFF)
-option_set(USE_OLD_PROPAGATOR             "Use old propagator for comparing to past results"         OFF)
 
 if (${BUILD_TARGET} STREQUAL "ms")
   add_definitions(-DARTED_MS)
@@ -120,7 +119,6 @@ endif ()
 add_definitions_if(ENABLE_CURRENT_PREPROCESSING -DARTED_CURRENT_PREPROCESSING)
 add_definitions_if(ENABLE_REDUCE_FOR_MANYCORE   -DARTED_REDUCE_FOR_MANYCORE)
 add_definitions_if(ENABLE_LARGE_BLOCKING        -DARTED_LBLK)
-add_definitions_if(USE_OLD_PROPAGATOR           -DARTED_USE_OLD_PROPAGATOR)
 
 if (OPT_STENCIL)
   add_definitions(-DARTED_STENCIL_OPTIMIZED)

--- a/common/preprocessor.f90
+++ b/common/preprocessor.f90
@@ -53,7 +53,4 @@ subroutine print_optimize_message
 #ifdef ARTED_ENABLE_SOFTWARE_PREFETCH
   print *, '  ARTED_ENABLE_SOFTWARE_PREFETCH'
 #endif
-#ifdef ARTED_USE_OLD_PROPAGATOR
-  print *, '  ARTED_USE_OLD_PROPAGATOR'
-#endif
 end subroutine

--- a/configure.py
+++ b/configure.py
@@ -66,7 +66,6 @@ group.add_option('--domain-pow2',         action='store_true',  dest='domain_two
 group.add_option('--loop-blocking',       action='store_true',  dest='loop_blocking',     help='loop blocking applied to the stencil computation.')
 group.add_option('--opt-current',         action='store_true',  dest='current_optimized', help='enable the current routine optimization in RT.')
 group.add_option('--reduce-manycore',     action='store_true',  dest='reduce_manycore',   help='enable reduction code optimization for many-core processor.')
-group.add_option('--use-old-propagator',  action='store_true',  dest='old_propagator',    help='use old propagator for comparing to past simulation results.')
 parser.add_option_group(group)
 
 group = OptionGroup(parser, 'Debug options')
@@ -102,7 +101,6 @@ add_option(dict, 'ENABLE_EXPLICIT_VEC',        options.explicit_vec)
 add_option(dict, 'ENABLE_LOOP_BLOCKING',       options.loop_blocking)
 add_option(dict, 'ENABLE_SWPREFETCH',          options.swp)
 add_option(dict, 'ENABLE_REDUCE_FOR_MANYCORE', options.reduce_manycore)
-add_option(dict, 'USE_OLD_PROPAGATOR',         options.old_propagator)
 if options.simd is not None:
   dict['SIMD_SET'] = options.simd.upper()
 

--- a/data/input_ms.dat
+++ b/data/input_ms.dat
@@ -4,6 +4,7 @@
 'Si'                                ! SYSname
 './data/'                                ! directory
 'PZ', 1.00d0                              ! functional 'PZ','PBE','TBmBJ','TPSS','VS98'
+'etrs'                              ! propagator 'default','etrs'
 'KY'                                ! ps_format 'KY','ABINIT','FHI'
 'n'          			    ! PSmask_option 'y' or 'n'
 0.8d0  1.8d0  15.d0                ! alpha_mask, gamma_mask, eta_mask

--- a/data/input_ms_Si.cpu.dat
+++ b/data/input_ms_Si.cpu.dat
@@ -4,6 +4,7 @@
 'Si'                                ! SYSname
 './data/'                                ! directory
 'PZ', 1.00d0                              ! functional 'PZ','PBE','TBmBJ','TPSS','VS98'
+'etrs'                              ! propagator 'default','etrs'
 'KY'                                ! ps_format 'KY','ABINIT','FHI'
 'n'                   ! PSmask_option 'y' or 'n'
 0.8d0  1.8d0  15.d0                ! alpha_mask, gamma_mask, eta_mask

--- a/data/input_ms_Si.dat
+++ b/data/input_ms_Si.dat
@@ -4,6 +4,7 @@
 'Si'                                ! SYSname
 './data/'                                ! directory
 'PZ', 1.00d0                              ! functional 'PZ','PBE','TBmBJ','TPSS','VS98'
+'etrs'                              ! propagator 'default','etrs'
 'KY'                                ! ps_format 'KY','ABINIT','FHI'
 'n'                   ! PSmask_option 'y' or 'n'
 0.8d0  1.8d0  15.d0                ! alpha_mask, gamma_mask, eta_mask

--- a/data/input_ms_Si.sym.dat
+++ b/data/input_ms_Si.sym.dat
@@ -4,6 +4,7 @@
 'Si'                                ! SYSname
 './data/'                                ! directory
 'PZ', 1.00d0                              ! functional 'PZ','PBE','TBmBJ','TPSS','VS98'
+'etrs'                              ! propagator 'default','etrs'
 'KY'                                ! ps_format 'KY','ABINIT','FHI'
 'n'                   ! PSmask_option 'y' or 'n'
 0.8d0  1.8d0  15.d0                ! alpha_mask, gamma_mask, eta_mask

--- a/data/input_ms_Si.verify.dat
+++ b/data/input_ms_Si.verify.dat
@@ -4,6 +4,7 @@
 'Si'                                ! SYSname
 './data/'                                ! directory
 'PZ', 1.00d0                              ! functional 'PZ','PBE','TBmBJ','TPSS','VS98'
+'etrs'                              ! propagator 'default','etrs'
 'KY'                                ! ps_format 'KY','ABINIT','FHI'
 'n'                   ! PSmask_option 'y' or 'n'
 0.8d0  1.8d0  15.d0                ! alpha_mask, gamma_mask, eta_mask

--- a/data/input_ms_Si_small.dat
+++ b/data/input_ms_Si_small.dat
@@ -4,6 +4,7 @@
 'Si'                                ! SYSname
 './data/'                                ! directory
 'PZ', 1.00d0                              ! functional 'PZ','PBE','TBmBJ','TPSS','VS98'
+'etrs'                              ! propagator 'default','etrs'
 'KY'                                ! ps_format 'KY','ABINIT','FHI'
 'n'                   ! PSmask_option 'y' or 'n'
 0.8d0  1.8d0  15.d0                ! alpha_mask, gamma_mask, eta_mask

--- a/data/input_sc.dat
+++ b/data/input_sc.dat
@@ -4,6 +4,7 @@
 'SiO2'                                ! SYSname
 './data/'                                ! directory
 'PZ', 1.00d0                        ! functional 'PZ','PBE','TBmBJ','TPSS','VS98'
+'etrs'                              ! propagator 'default','etrs'
 'KY'                                ! ps_format 'KY','ABINIT','FHI'
 'n'          			    ! PSmask_option 'y' or 'n'
 0.8d0  1.8d0  15.d0                ! alpha_mask, gamma_mask, eta_mask

--- a/data/input_sc_Si.dat
+++ b/data/input_sc_Si.dat
@@ -4,6 +4,7 @@
 'Si'                                ! SYSname
 './data/'                                ! directory
 'PZ', 1.00d0                        ! functional 'PZ','PBE','TBmBJ','TPSS','VS98'
+'etrs'                              ! propagator 'default','etrs'
 'KY'                                ! ps_format 'KY','ABINIT','FHI'
 'n'          			    ! PSmask_option 'y' or 'n'
 0.8d0  1.8d0  15.d0                ! alpha_mask, gamma_mask, eta_mask

--- a/data/input_sc_Si.single.dat
+++ b/data/input_sc_Si.single.dat
@@ -4,6 +4,7 @@
 'Si'                                ! SYSname
 './data/'                                ! directory
 'PZ', 1.00d0                        ! functional 'PZ','PBE','TBmBJ','TPSS','VS98'
+'etrs'                              ! propagator 'default','etrs'
 'KY'                                ! ps_format 'KY','ABINIT','FHI'
 'n'          			    ! PSmask_option 'y' or 'n'
 0.8d0  1.8d0  15.d0                ! alpha_mask, gamma_mask, eta_mask

--- a/data/input_sc_Si.verify.dat
+++ b/data/input_sc_Si.verify.dat
@@ -4,6 +4,7 @@
 'Si'                                ! SYSname
 './data/'                                ! directory
 'PZ', 1.00d0                        ! functional 'PZ','PBE','TBmBJ','TPSS','VS98'
+'etrs'                              ! propagator 'default','etrs'
 'KY'                                ! ps_format 'KY','ABINIT','FHI'
 'n'          			    ! PSmask_option 'y' or 'n'
 0.8d0  1.8d0  15.d0                ! alpha_mask, gamma_mask, eta_mask

--- a/data/input_sc_SiO2.dat
+++ b/data/input_sc_SiO2.dat
@@ -4,6 +4,7 @@
 'SiO2'                                ! SYSname
 './data/'                                ! directory
 'PZ', 1.00d0                        ! functional 'PZ','PBE','TBmBJ','TPSS','VS98'
+'etrs'                              ! propagator 'default','etrs'
 'KY'                                ! ps_format 'KY','ABINIT','FHI'
 'n'          			    ! PSmask_option 'y' or 'n'
 0.8d0  1.8d0  15.d0                ! alpha_mask, gamma_mask, eta_mask

--- a/data/input_sc_Si_small.dat
+++ b/data/input_sc_Si_small.dat
@@ -4,6 +4,7 @@
 'Si'                                ! SYSname
 './data/'                                ! directory
 'PZ', 1.00d0                        ! functional 'PZ','PBE','TBmBJ','TPSS','VS98'
+'etrs'                              ! propagator 'default','etrs'
 'KY'                                ! ps_format 'KY','ABINIT','FHI'
 'n'          			    ! PSmask_option 'y' or 'n'
 0.8d0  1.8d0  15.d0                ! alpha_mask, gamma_mask, eta_mask

--- a/data/input_sc_diamond2.dat
+++ b/data/input_sc_diamond2.dat
@@ -4,6 +4,7 @@
 'diamond'                                ! SYSname
 './'                                ! directory
 'TBmBJ', 1.28d0                     ! functional 'PZ','PBE','TBmBJ','TPSS','VS98'
+'etrs'                              ! propagator 'default','etrs'
 'KY'                                ! ps_format 'KY','ABINIT','FHI'
 'n'          			    ! PSmask_option 'y' or 'n'
 0.8d0  1.8d0  15.d0                ! alpha_mask, gamma_mask, eta_mask

--- a/main/ms.f90
+++ b/main/ms.f90
@@ -359,28 +359,9 @@ Program main
         Vloc(:)=Vloc_m(:,ixy_m)
         Vloc_old(:,:)=Vloc_old_m(:,:,ixy_m)
       end if
-
-
-      
-#ifdef ARTED_USE_OLD_PROPAGATOR
-      kAc(:,1)=kAc0(:,1)+(Ac_new_m(1,ix_m,iy_m)+Ac_m(1,ix_m,iy_m))/2d0
-      kAc(:,2)=kAc0(:,2)+(Ac_new_m(2,ix_m,iy_m)+Ac_m(2,ix_m,iy_m))/2d0
-      kAc(:,3)=kAc0(:,3)+(Ac_new_m(3,ix_m,iy_m)+Ac_m(3,ix_m,iy_m))/2d0
-!$acc update device(kAc)
-
       call timer_end(LOG_OTHER)
-      
-      call dt_evolve_omp_KB_MS
-#else
-      kAc(:,1)=kAc0(:,1)+Ac_m(1,ix_m,iy_m)
-      kAc(:,2)=kAc0(:,2)+Ac_m(2,ix_m,iy_m)
-      kAc(:,3)=kAc0(:,3)+Ac_m(3,ix_m,iy_m)
-      kAc_new(:,1)=kAc0(:,1)+Ac_new_m(1,ix_m,iy_m)
-      kAc_new(:,2)=kAc0(:,2)+Ac_new_m(2,ix_m,iy_m)
-      kAc_new(:,3)=kAc0(:,3)+Ac_new_m(3,ix_m,iy_m)
-!$acc update device(kAc)
-      call dt_evolve_etrs_omp_KB
-#endif
+
+      call dt_evolve_KB_MS(ix_m,iy_m)
 
       call timer_begin(LOG_OTHER)
 ! sato ---------------------------------------

--- a/main/ms.f90
+++ b/main/ms.f90
@@ -664,6 +664,7 @@ Subroutine Read_data
 !yabana
     read(*,*) functional, cval
 !yabana
+    read(*,*) propagator
     read(*,*) ps_format !shinohara
     read(*,*) PSmask_option !shinohara
     read(*,*) alpha_mask, gamma_mask, eta_mask !shinohara
@@ -689,6 +690,7 @@ Subroutine Read_data
     write(*,*) 'functional=',functional
     if(functional == 'TBmBJ') write(*,*) 'cvalue=',cval
 !yabana
+    write(*,*) 'propagator=',propagator
     write(*,*) 'ps_format =',ps_format !shinohara
     write(*,*) 'PSmask_option =',PSmask_option !shinohara
     write(*,*) 'alpha_mask, gamma_mask, eta_mask =',alpha_mask, gamma_mask, eta_mask !shinohara
@@ -722,6 +724,7 @@ Subroutine Read_data
   call comm_bcast(functional,proc_group(1))
   call comm_bcast(cval,proc_group(1))
 !yabana
+  call comm_bcast(propagator,proc_group(1))
 
   call comm_bcast(ps_format,proc_group(1))!shinohara
   call comm_bcast(PSmask_option,proc_group(1))!shinohara
@@ -1239,6 +1242,8 @@ subroutine prep_Reentrance_Read
   read(500) FSset_option,MD_option
   read(500) AD_RHO !ovlp_option
 
+  read(500) propagator
+
 !  integer :: procid(1),Nprocs
 !  integer :: NEW_COMM_WORLD,nprocs(2),procid(2) ! sato
   read(500) NK_ave,NG_ave,NK_s,NK_e,NG_s,NG_e
@@ -1485,6 +1490,8 @@ subroutine prep_Reentrance_write
   write(500) Longi_Trans
   write(500) FSset_option,MD_option
   write(500) AD_RHO !ovlp_option
+
+  write(500) propagator
 
 !  integer :: procid(1),Nprocs
 !  integer :: NEW_COMM_WORLD,nprocs(2),procid(2) ! sato

--- a/main/sc.f90
+++ b/main/sc.f90
@@ -584,6 +584,7 @@ Subroutine Read_data
 !yabana
     read(*,*) functional, cval
 !yabana
+    read(*,*) propagator
     read(*,*) ps_format !shinohara
     read(*,*) PSmask_option !shinohara
     read(*,*) alpha_mask, gamma_mask, eta_mask !shinohara
@@ -604,6 +605,7 @@ Subroutine Read_data
     write(*,*) 'functional=',functional
     if(functional == 'TBmBJ') write(*,*) 'cvalue=',cval
 !yabana
+    write(*,*) 'propagator=',propagator
     write(*,*) 'ps_format =',ps_format !shinohara
     write(*,*) 'PSmask_option =',PSmask_option !shinohara
     write(*,*) 'alpha_mask, gamma_mask, eta_mask =',alpha_mask, gamma_mask, eta_mask !shinohara
@@ -629,6 +631,7 @@ Subroutine Read_data
   call comm_bcast(directory,proc_group(1))
   call comm_bcast(functional,proc_group(1))
   call comm_bcast(cval,proc_group(1))
+  call comm_bcast(propagator,proc_group(1))
 
   call comm_bcast(ps_format,proc_group(1))
   call comm_bcast(PSmask_option,proc_group(1))
@@ -1081,6 +1084,7 @@ subroutine prep_Reentrance_Read
   read(500) functional
   read(500) cval ! cvalue for TBmBJ. If cval<=0, calculated in the program
 !yabana
+  read(500) propagator
 
 !  read(500) procid(1),nprocs(1),ierr
 !  read(500) proc_group(2),NEWPROCS,NEWRANK ! sato
@@ -1357,6 +1361,7 @@ subroutine prep_Reentrance_write
   write(500) functional
   write(500) cval ! cvalue for TBmBJ. If cval<=0, calculated in the program
 !yabana
+  write(500) propagator
 
 !  write(500) procid(1),nprocs(1),ierr
 !  write(500) proc_group(2),NEWPROCS,NEWRANK ! sato

--- a/main/sc.f90
+++ b/main/sc.f90
@@ -335,21 +335,7 @@ Program main
       Ac_tot(iter+1,:)=Ac_ext(iter+1,:)
     end if
 
-
-#ifdef ARTED_USE_OLD_PROPAGATOR
-    do ixyz=1,3
-      kAc(:,ixyz)=kAc0(:,ixyz)+0.5d0*(Ac_tot(iter,ixyz) + Ac_tot(iter+1,ixyz) )
-    enddo
-!$acc update device(kAc)
-    call dt_evolve_omp_KB
-#else
-    do ixyz=1,3
-      kAc(:,ixyz)=kAc0(:,ixyz)+Ac_tot(iter,ixyz)
-      kAc_new(:,ixyz)=kAc0(:,ixyz)+Ac_tot(iter+1,ixyz)
-    enddo
-!$acc update device(kAc,kAc_new)
-    call dt_evolve_etrs_omp_KB
-#endif
+    call dt_evolve_KB(iter)
 
     do ixyz=1,3
       kAc(:,ixyz)=kAc0(:,ixyz)+Ac_tot(iter+1,ixyz)

--- a/modules/global_variables.f90
+++ b/modules/global_variables.f90
@@ -145,6 +145,7 @@ Module Global_Variables
   character(10) :: functional
   real(8) :: cval ! cvalue for TBmBJ. If cval<=0, calculated in the program
 !yabana
+  character(10) :: propagator = 'default' ! propagation scheme: default, or etrs
 
   integer :: NK_ave,NG_ave,NK_s,NK_e,NG_s,NG_e
   integer :: NK_remainder,NG_remainder

--- a/modules/performance_analyzer.f90
+++ b/modules/performance_analyzer.f90
@@ -155,7 +155,7 @@ contains
   end subroutine
 
   subroutine summation_threads(lgflops)
-    use global_variables, only: NUMBER_THREADS, functional
+    use global_variables, only: NUMBER_THREADS, functional, propagator
     use timer
     implicit none
     real(8), intent(out) :: lgflops(4)
@@ -170,11 +170,11 @@ contains
       case default
         ncalls_in_loop = 2
     end select
-#ifdef ARTED_SC
-#ifdef ARTED_USE_OLD_PROPAGATOR
-    ncalls_in_loop = ncalls_in_loop - 1
-#endif
-#endif
+
+    select case(propagator)
+      case('default')
+        ncalls_in_loop = ncalls_in_loop - 1
+    end select
 
     call get_hamiltonian_chunk_size(chunk_size)
 


### PR DESCRIPTION
By this PR, a propagation scheme can be selected at runtime.
ARTED saves selected propagation scheme to `propagator` variable in `modules/global_variables.f90`.

`propagator` value means,

- `default`
    (modified) old scheme
- `etrs`
    enforced time-reversal symmetry scheme