### PR TITLE
Add "input" option for AE_Shape

### DIFF
--- a/FDTD/FDTD.f90
+++ b/FDTD/FDTD.f90
@@ -127,8 +127,12 @@ subroutine init_Ac_ms_2dc()
   jmatter_m=0d0
   jmatter_m_l=0d0
   energy_joule=0d0
-  call incident_bessel_beam()
-  
+  select case(AE_shape)
+  case('Asin2cos')
+    call incident_bessel_beam()
+  case('input')
+    call read_initial_ac_from_file()
+  end select 
   call comm_sync_all
   return
 end subroutine init_Ac_ms_2dc

--- a/FDTD/beam.f90
+++ b/FDTD/beam.f90
@@ -104,3 +104,31 @@ subroutine incident_bessel_beam()
   Ac_m(:,:,NYvacB_m-1) = Ac_m(:,:,NYvacB_m)
   return
 end subroutine incident_bessel_beam
+
+
+subroutine read_initial_ac_from_file()
+  use Global_Variables, only: SYSName, directory,file_ac_init, &
+                            & Ac_m, Ac_new_m
+  use communication, only: comm_is_root, comm_bcast, proc_group
+  implicit none
+  integer :: ix_m, iy_m
+  integer :: nx1_m, nx2_m, ny1_m, ny2_m
+  
+  write(file_ac_init, "(A,A,'_Ac_init.dat')") trim(directory), trim(SYSname)
+  if (comm_is_root(1)) then
+    Ac_m = 0.0
+    Ac_new_m = 0.0
+    open(944, file=trim(file_ac_init))
+    read(944, *) nx1_m, nx2_m
+    read(944, *) ny1_m, ny2_m
+    do iy_m = ny1_m, ny2_m
+      do ix_m = nx1_m, nx2_m
+        read(944, *) Ac_m(:, ix_m, iy_m), Ac_new_m(:, ix_m, iy_m)
+      end do
+    end do
+    close(944)
+  end if
+  call comm_bcast(Ac_m, proc_group(1))
+  call comm_bcast(Ac_new_m, proc_group(1))
+  return
+end subroutine 

--- a/main/ms.f90
+++ b/main/ms.f90
@@ -1105,7 +1105,7 @@ Subroutine Read_data
 
   NYvacB_m = 1
   NYvacT_m = NY_m  
-  allocate(Ac_m(1:3,NXvacL_m-1:NXvacR_m+1,0:NY_m+1))
+  allocate(Ac_m(1:3,NXvacL_m-1:NXvacR_m+1,NYvacB_m-1:NYvacT_m+1))
   allocate(Ac_old_m(1:3,NXvacL_m-1:NXvacR_m+1,NYvacB_m-1:NYvacT_m+1))
   allocate(Ac_new_m(1:3,NXvacL_m-1:NXvacR_m+1,NYvacB_m-1:NYvacT_m+1))
   allocate(g(1:3,NXvacL_m-1:NXvacR_m+1,NYvacB_m-1:NYvacT_m+1))

--- a/modules/global_variables.f90
+++ b/modules/global_variables.f90
@@ -141,6 +141,7 @@ Module Global_Variables
   character(256) :: file_ac_vac_back     ! 942
   character(256) :: file_ac_m            ! 943
   character(256) :: file_ac              ! 902
+  character(256) :: file_ac_init         ! 902
   character(256) :: process_directory
 
   character(2) :: ext_field


### PR DESCRIPTION
- This modification provides a new option for `AE_Shape` parameter for multi scale calculation.
- In the case of `AE_Shape="input"`, the macroscopic EM field is initialized by external datafile `SYSName_Ac_init.dat`. This helps to calculation test of FDTD part.