### PR TITLE
Improve numerical precision of Maxwell solver for cylindrical coordinates

### DIFF
--- a/FDTD/FDTD.f90
+++ b/FDTD/FDTD.f90
@@ -460,7 +460,6 @@ subroutine dt_evolve_Ac_2dc()
   implicit none
   integer :: ix_m, iy_m
   real(8) :: Y, RR(3) ! rot rot Ac
-  ! (written by M.Uemoto on 2016-11-22)
 
 !$omp parallel do collapse(2) default(none) &
 !$    private(iy_m,ix_m) &
@@ -479,7 +478,7 @@ subroutine dt_evolve_Ac_2dc()
 !$    firstprivate(dt)
   do iy_m=NYvacB_m,NYvacT_m
     do ix_m=NXvacL_m,NXvacR_m
-      Y = (iy_m - 0.50d0) * HY_m
+      Y = iy_m * HY_m
       RR(1) = +(+0.50d0*(1.00d0/HY_m)*(1.00d0/Y)-(1.00d0/HY_m**2))*Ac_m(1,ix_m+0,iy_m-1) &
             & +2.00d0*(1.00d0/HY_m**2)*Ac_m(1,ix_m+0,iy_m+0) &
             & +(-0.50d0*(1.00d0/HY_m)*(1.00d0/Y)-(1.00d0/HY_m**2))*Ac_m(1,ix_m+0,iy_m+1) &
@@ -512,8 +511,10 @@ subroutine dt_evolve_Ac_2dc()
 !$    private(ix_m) &
 !$    shared(Ac_new_m,NXvacL_m,NXvacR_m,NYvacB_m,NYvacT_m)
   do ix_m=NXvacL_m-1,NXvacR_m+1
-    Ac_new_m(:,ix_m,NYvacB_m-1)=Ac_new_m(:,ix_m,NYvacB_m)
-    Ac_new_m(:,ix_m,NYvacT_m+1)=0.0d0
+    Ac_new_m(1,ix_m,NYvacB_m-1)=Ac_new_m(1,ix_m,NYvacB_m)
+    !!Following BCs are automatically satisfied by adequate initial state.
+    !Ac_new_m(2:3,ix_m,NYvacB_m-1)=0.0d0
+    !Ac_new_m(:,ix_m,NYvacT_m+1)=0.0d0
   enddo
 !$omp end parallel do
   return
@@ -546,8 +547,6 @@ subroutine calc_elec_field()
                             & dt
   implicit none
   integer ix_m,iy_m
-  ! calculate the electric field from the vector potential Ac
-  ! (written by M.Uemoto on 2016-11-22)
 
 !$omp parallel do collapse(2) default(none) &
 !$    private(iy_m,ix_m) &
@@ -623,7 +622,7 @@ subroutine calc_bmag_field_2dc()
 !$    shared(NYvacB_m,NYvacT_m,NXvacL_m,NXvacR_m,HY_m,HX_m,Bmag,Ac_m)
   do iy_m=NYvacB_m, NYvacT_m
     do ix_m=NXvacL_m, NXvacR_m
-      Y = (iy_m-0.5d0) * HY_m
+      Y = iy_m * HY_m
       Rc(1) = -0.50d0*(1.00d0/HY_m)*Ac_m(3,ix_m+0,iy_m-1) &
             & +1.00d0*(1.00d0/Y)*Ac_m(3,ix_m+0,iy_m+0) &
             & +0.50d0*(1.00d0/HY_m)*Ac_m(3,ix_m+0,iy_m+1)

--- a/FDTD/beam.f90
+++ b/FDTD/beam.f90
@@ -68,7 +68,7 @@ subroutine incident_bessel_beam()
   wpulse_1 = 2*pi/tpulse_1
 
   lx = (NXvacR_m-NXvacL_m) * HX_m
-  ly = NYvacT_m * HY_m
+  ly = (NYvacT_m+1) * HY_m
 
   ky = 3.8317d0 / ly
   k = omega_1 / c_light
@@ -83,7 +83,7 @@ subroutine incident_bessel_beam()
   Ac_m = 0.0
   Ac_new_m = 0.0
   do iy_m = NYvacB_m, NYvacT_m
-     y = HY_m * (iy_m - 0.5)
+     y = HY_m * iy_m
      j = bessel_j1(ky * y)
      f = j * f0_1 / 0.58186d0 * Epdir_1
      do ix_m = NXvacL_m-1, 0
@@ -98,10 +98,12 @@ subroutine incident_bessel_beam()
   end do
   
   ! impose boundary condition
-  Ac_new_m(:,:,NYvacT_m+1) = 0.0
-  Ac_new_m(:,:,NYvacB_m-1) = Ac_new_m(:,:,NYvacB_m)
-  Ac_m(:,:,NYvacT_m+1) = 0.0
-  Ac_m(:,:,NYvacB_m-1) = Ac_m(:,:,NYvacB_m)
+  Ac_new_m(:,:,NYvacT_m+1) = 0.0d0
+  Ac_new_m(2:3,:,NYvacB_m-1) = 0.0d0
+  Ac_new_m(1,:,NYvacB_m-1) = Ac_m(1,:,NYvacB_m)
+  Ac_m(:,:,NYvacT_m+1) = 0.0d0
+  Ac_m(2:3,:,NYvacB_m-1) = 0.0d0
+  Ac_m(1,:,NYvacB_m-1) = Ac_m(1,:,NYvacB_m)
   return
 end subroutine incident_bessel_beam
 


### PR DESCRIPTION
- This patch modifies the `dt_evolve_Ac` and initial pulse generation for 2DC mode in order to improve the numerical precision to Maxwell equation solver.