### PR TITLE
Fixed a array out-of-bounds error.

### DIFF
--- a/RT/dt_evolve.f90
+++ b/RT/dt_evolve.f90
@@ -177,7 +177,7 @@ Subroutine dt_evolve_omp_KB(zu)
 
   call psi_rho_RT(zu)
   call Hartree
-  call Exc_Cor('RT',NBoccmax,zu)
+  call Exc_Cor(calc_mode_rt,NBoccmax,zu)
 
 !$omp parallel do
   do i=1,NL
@@ -217,7 +217,7 @@ Subroutine dt_evolve_omp_KB(zu)
 
 ! yabana
   NVTX_BEG('dt_evolve_omp_KB(): Exc_Cor',6)
-  call Exc_Cor('RT',NBoccmax,zu)
+  call Exc_Cor(calc_mode_rt,NBoccmax,zu)
   NVTX_END()
 ! yabana
 
@@ -358,7 +358,7 @@ Subroutine dt_evolve_etrs_omp_KB(zu)
      NVTX_END()
 
      NVTX_BEG('dt_evolve_omp_KB(): Exc_Cor',6)
-     call Exc_Cor('RT',NBoccmax,zu)
+     call Exc_Cor(calc_mode_rt,NBoccmax,zu)
      NVTX_END()
 
 #ifdef _OPENACC
@@ -394,7 +394,7 @@ Subroutine dt_evolve_etrs_omp_KB(zu)
   NVTX_END()
 
   NVTX_BEG('dt_evolve_omp_KB(): Exc_Cor',6)
-  call Exc_Cor('RT',NBoccmax,zu)
+  call Exc_Cor(calc_mode_rt,NBoccmax,zu)
   NVTX_END()
 
 
@@ -484,7 +484,7 @@ Subroutine dt_evolve_omp_KB_MS(zu)
 
   call psi_rho_RT(zu)
   call Hartree
-  call Exc_Cor('RT',NBoccmax,zu)
+  call Exc_Cor(calc_mode_rt,NBoccmax,zu)
 
 !$omp parallel do
   do i=1,NL
@@ -522,7 +522,7 @@ Subroutine dt_evolve_omp_KB_MS(zu)
 
 ! yabana
   NVTX_BEG('dt_evolve_omp_KB_MS(): Hartree',5)
-  call Exc_Cor('RT',NBoccmax,zu)
+  call Exc_Cor(calc_mode_rt,NBoccmax,zu)
   NVTX_END()
 ! yabana
 

--- a/RT/k_shift_wf.f90
+++ b/RT/k_shift_wf.f90
@@ -21,9 +21,10 @@ Subroutine k_shift_wf(atomic_position_update_switch,iter_GS_max,zu)
   use Global_Variables
   use communication
   implicit none
-  integer :: iter_GS,iter_GS_max,ik,ib1,ib2
-  character(3) :: atomic_position_update_switch
+  integer,intent(in) :: iter_GS_max
+  integer,intent(in) :: atomic_position_update_switch
   complex(8),intent(in) :: zu(NL,NBoccmax,NK_s:NK_e)
+  integer :: iter_GS,ik,ib1,ib2
 
   if(AD_RHO == 'GS')then
     Vloc_t(:)=Vloc(:)
@@ -34,8 +35,8 @@ Subroutine k_shift_wf(atomic_position_update_switch,iter_GS_max,zu)
   do iter_GS=1,iter_GS_max
     call CG_omp(Ncg)
     call Gram_Schmidt
-    call Total_Energy_omp(atomic_position_update_switch,'GS')
-    call Ion_Force_omp(atomic_position_update_switch,'GS')
+    call Total_Energy_omp(atomic_position_update_switch,calc_mode_gs)
+    call Ion_Force_omp(atomic_position_update_switch,calc_mode_gs)
     if (comm_is_root()) then
       write(*,'(1x,a15,i3,f20.14,f15.8)')'iter_GS, Eall =',iter_GS,Eall-Eall0,force(3,1)
     end if
@@ -65,10 +66,11 @@ Subroutine k_shift_wf_last(atomic_position_update_switch,iter_GS_max,zu)
   use Global_Variables
   use communication
   implicit none
-  integer :: iter_GS,iter_GS_max,ik,ib1,ib2,ib,ia
-  character(3) :: atomic_position_update_switch
-  real(8) :: esp_all(NB,NK)
+  integer,intent(in) :: iter_GS_max
+  integer,intent(in) :: atomic_position_update_switch
   complex(8),intent(in) :: zu(NL,NBoccmax,NK_s:NK_e)
+  real(8) :: esp_all(NB,NK)
+  integer :: iter_GS,ik,ib1,ib2,ib,ia
 
   if(AD_RHO == 'GS')then
     Vloc_t(:)=Vloc(:)
@@ -79,8 +81,8 @@ Subroutine k_shift_wf_last(atomic_position_update_switch,iter_GS_max,zu)
   do iter_GS=1,iter_GS_max
     call CG_omp(Ncg)
     call Gram_Schmidt
-    call Total_Energy_omp(atomic_position_update_switch,'GS')
-    call Ion_Force_omp(atomic_position_update_switch,'GS')
+    call Total_Energy_omp(atomic_position_update_switch,calc_mode_gs)
+    call Ion_Force_omp(atomic_position_update_switch,calc_mode_gs)
     if (comm_is_root()) then
       write(*,'(1x,a15,i3,f20.14,f15.8)')'iter_GS, Eall =',iter_GS,Eall-Eall0,force(3,1)
     end if

--- a/common/Exc_Cor.f90
+++ b/common/Exc_Cor.f90
@@ -18,7 +18,7 @@ subroutine Exc_Cor(GS_RT,NBtmp,zu)
   use Global_Variables
   use timer
   implicit none
-  character(2) :: GS_RT
+  integer,intent(in)       :: GS_RT
   integer,intent(in)       :: NBtmp
   complex(8),intent(inout) :: zu(NL,NBtmp,NK_s:NK_e)
   call timer_begin(LOG_EXC_COR)
@@ -79,7 +79,7 @@ End Subroutine Exc_Cor_PZM
 Subroutine Exc_Cor_PBE(GS_RT)
   use Global_Variables
   implicit none
-  character(2) :: GS_RT
+  integer,intent(in) :: GS_RT
   real(8) :: rho_s(NL),tau_s(NL),j_s(NL,3),grho_s(NL,3),lrho_s(NL)
   real(8) :: agrho_s(NL)
   integer :: i
@@ -153,7 +153,7 @@ Subroutine Exc_Cor_TBmBJ(GS_RT)
   use Global_Variables
   implicit none
   real(8),parameter :: alpha=-0.012d0,beta=1.023d0,gamma=0.80d0
-  character(2) :: GS_RT
+  integer,intent(in) :: GS_RT
   real(8) :: rho_s(NL),tau_s(NL),j_s(NL,3),grho_s(NL,3),lrho_s(NL)
   real(8) :: c,tau_s_jrho,D_s_jrho,Q_s,rhs,x_s,b_s,Vx_BR,Vx_MBJ
   real(8) :: trho,rs,rhos,ec,dec_drhoa,dec_drhob
@@ -232,7 +232,7 @@ end subroutine BR_Newton
 Subroutine Exc_Cor_TPSS(GS_RT)
   use Global_Variables
   implicit none
-  character(2) :: GS_RT
+  integer,intent(in) :: GS_RT
   integer i
   real(8),parameter :: kappa=0.804d0,c=1.59096d0,e=1.537d0,mu=0.21951d0
   real(8),parameter :: b=0.40d0,d=2.8d0,C0=0.53d0
@@ -349,7 +349,7 @@ Subroutine Exc_Cor_TPSS(GS_RT)
 Subroutine Exc_Cor_VS98(GS_RT)
   use Global_Variables
   implicit none
-  character(2) :: GS_RT
+  integer,intent(in) :: GS_RT
   real(8),parameter :: CF=3d0/5d0*(3*Pi**2)**(2d0/3d0)
   real(8),parameter :: alp_ex=0.00186726d0,alp_aa=0.00515088d0,alp_ab=0.00304966d0
   real(8),parameter :: a_ex=-0.9800683d0,a_aa=0.3270912d0,a_ab=0.7035010d0
@@ -922,8 +922,8 @@ Subroutine rho_j_tau(GS_RT,rho_s,tau_s,j_s,grho_s,lrho_s)
   use Global_Variables
   use communication
   implicit none
-  character(2) :: GS_RT
-  real(8) :: rho_s(NL),tau_s(NL),j_s(NL,3),grho_s(NL,3),lrho_s(NL)
+  integer,intent(in)    :: GS_RT
+  real(8),intent(inout) :: rho_s(NL),tau_s(NL),j_s(NL,3),grho_s(NL,3),lrho_s(NL)
   integer :: ikb,ik,ib,i
   real(8) :: tau_s_l(NL),j_s_l(NL,3),ss(3)
   complex(8) :: zs(3)
@@ -936,7 +936,7 @@ Subroutine rho_j_tau(GS_RT,rho_s,tau_s,j_s,grho_s,lrho_s)
   tau_s_l_omp=0d0
   j_s_l_omp=0d0
 
-  if(GS_RT == 'GS')then
+  if(GS_RT == calc_mode_gs)then
 
     select case(Nd)
     case(4)
@@ -976,7 +976,7 @@ Subroutine rho_j_tau(GS_RT,rho_s,tau_s,j_s,grho_s,lrho_s)
       call err_finalize('Nd /= 4')
     end select
   
-  else  if(GS_RT == 'RT')then
+  else  if(GS_RT == calc_mode_rt)then
 
     select case(Nd)
     case(4)

--- a/common/ion_force.f90
+++ b/common/ion_force.f90
@@ -15,21 +15,24 @@
 !
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 subroutine Ion_Force_omp(Rion_update,GS_RT,ixy_m)
-  use Global_Variables, only: zu_t,zu_m,zu_GS,NB,NBoccmax
+  use Global_Variables, only: zu_t,zu_m,zu_GS,NB,NBoccmax,calc_mode_gs,calc_mode_rt
   implicit none
-  character(2),intent(in) :: GS_RT
-  character(3),intent(in) :: Rion_update
+  integer,intent(in) :: GS_RT
+  logical,intent(in) :: Rion_update
   integer,intent(in),optional :: ixy_m
 
-  if(GS_RT == 'GS') then
-    call impl(Rion_update,zu_GS,NB)
-  else if(GS_RT == 'RT') then
-    if (present(ixy_m)) then
-      call impl(Rion_update,zu_m(:,:,:,ixy_m),NBoccmax)
-    else
-      call impl(Rion_update,zu_t,NBoccmax)
-    end if
-  end if
+  select case(GS_RT)
+    case(calc_mode_gs)
+      call impl(Rion_update,zu_GS,NB)
+    case(calc_mode_rt)
+      if (present(ixy_m)) then
+        call impl(Rion_update,zu_m(:,:,:,ixy_m),NBoccmax)
+      else
+        call impl(Rion_update,zu_t,NBoccmax)
+      end if
+    case default
+      call err_finalize('ion_force_omp: gs_rt flag')
+  end select
 
 contains
   subroutine impl(Rion_update,zutmp,zu_NB)
@@ -37,7 +40,7 @@ contains
     use communication
     use timer
     implicit none
-    character(3),intent(in)  :: Rion_update
+    logical,intent(in)       :: Rion_update
     integer,intent(in)       :: zu_NB
     complex(8),intent(inout) :: zutmp(NL,zu_NB,NK_s:NK_e)
 
@@ -49,7 +52,7 @@ contains
     call timer_begin(LOG_ION_FORCE)
 
     !ion
-    if (Rion_update == 'on') then
+    if (Rion_update) then
       ftmp_l=0.d0
 !$omp parallel
       do ia=1,NI

--- a/common/total_energy.f90
+++ b/common/total_energy.f90
@@ -15,22 +15,25 @@
 !
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 subroutine Total_Energy_omp(Rion_update,GS_RT,ixy_m)
-  use Global_Variables, only: zu_t,zu_m,zu_GS,NB,NBoccmax
+  use Global_Variables, only: zu_t,zu_m,zu_GS,NB,NBoccmax,calc_mode_gs,calc_mode_rt
   use communication
   implicit none
-  character(3),intent(in) :: Rion_update
-  character(2),intent(in) :: GS_RT
+  integer,intent(in) :: GS_RT
+  logical,intent(in) :: Rion_update
   integer,intent(in),optional :: ixy_m
 
-  if (GS_RT == 'GS') then
-    call impl(Rion_update,zu_GS,NB)
-  else if (GS_RT == 'RT') then
-    if (present(ixy_m)) then
-      call impl(Rion_update,zu_m(:,:,:,ixy_m),NBoccmax)
-    else
-      call impl(Rion_update,zu_t,NBoccmax)
-    end if
-  end if
+  select case(GS_RT)
+    case(calc_mode_gs)
+      call impl(Rion_update,zu_GS,NB)
+    case(calc_mode_rt)
+      if (present(ixy_m)) then
+        call impl(Rion_update,zu_m(:,:,:,ixy_m),NBoccmax)
+      else
+        call impl(Rion_update,zu_t,NBoccmax)
+      end if
+    case default
+      call err_finalize('total_energy_omp: GS_RT flag')
+  end select
 
 contains
   subroutine impl(Rion_update,zutmp,zu_NB)
@@ -38,7 +41,7 @@ contains
     use Opt_Variables
     use timer
     implicit none
-    character(3),intent(in)  :: Rion_update
+    logical,intent(in)       :: Rion_update
     integer,intent(in)       :: zu_NB
     complex(8),intent(inout) :: zutmp(0:NL-1,zu_NB,NK_s:NK_e)
 
@@ -62,7 +65,7 @@ contains
     call timer_begin(LOG_TOTAL_ENERGY)
 
     !ion-ion
-    if (Rion_update == 'on') then
+    if (Rion_update) then
       thr_id=0
       Eion_tmp1=0.d0
       Eion_l=0.d0
@@ -175,7 +178,7 @@ contains
 
     call timer_begin(LOG_ALLREDUCE)
     !summarize
-    if (Rion_update == 'on') then
+    if (Rion_update) then
       call comm_summation(Eion_l,Eion_tmp2,proc_group(2))
       Eion=Eion_tmp1+Eion_tmp2
     end if

--- a/main/ms.f90
+++ b/main/ms.f90
@@ -28,7 +28,7 @@ Program main
   use misc_routines
   implicit none
   integer :: iter,ik,ib,ia
-  character(3) :: Rion_update
+  logical :: Rion_update
   character(10) :: functional_t
   integer :: ix_m,iy_m,ixy_m
   integer :: index, n
@@ -64,7 +64,7 @@ Program main
   Time_start=get_wtime() !reentrance
   call comm_bcast(Time_start,proc_group(1))
 
-  Rion_update='on'
+  Rion_update = rion_update_on
 
   call Read_data
   if (entrance_option == 'reentrance' ) go to 2
@@ -95,14 +95,14 @@ Program main
 ! yabana
   functional_t = functional
   if(functional_t == 'TBmBJ') functional = 'PZM'
-  call Exc_Cor('GS',NBoccmax,zu_t)
+  call Exc_Cor(calc_mode_gs,NBoccmax,zu_t)
   if(functional_t == 'TBmBJ') functional = 'TBmBJ'
 ! yabana
   Vloc(1:NL)=Vh(1:NL)+Vpsl(1:NL)+Vexc(1:NL)
-!  call Total_Energy(Rion_update,'GS')
-  call Total_Energy_omp(Rion_update,'GS') ! debug
-  call Ion_Force_omp(Rion_update,'GS')
-  if (MD_option /= 'Y') Rion_update = 'off'
+!  call Total_Energy(Rion_update,calc_mode_gs)
+  call Total_Energy_omp(Rion_update,calc_mode_gs) ! debug
+  call Ion_Force_omp(Rion_update,calc_mode_gs)
+  if (MD_option /= 'Y') Rion_update = rion_update_off
   Eall_GS(0)=Eall
 
   if(comm_is_root(1)) then
@@ -160,12 +160,12 @@ Program main
 ! yabana
     functional_t = functional
     if(functional_t == 'TBmBJ' .and. iter < 20) functional = 'PZM'
-    call Exc_Cor('GS',NBoccmax,zu_t)
+    call Exc_Cor(calc_mode_gs,NBoccmax,zu_t)
     if(functional_t == 'TBmBJ' .and. iter < 20) functional = 'TBmBJ'
 ! yabana
     Vloc(1:NL)=Vh(1:NL)+Vpsl(1:NL)+Vexc(1:NL)
-    call Total_Energy_omp(Rion_update,'GS')
-    call Ion_Force_omp(Rion_update,'GS')
+    call Total_Energy_omp(Rion_update,calc_mode_gs)
+    call Ion_Force_omp(Rion_update,calc_mode_gs)
     call sp_energy_omp
     call current_GS
     Eall_GS(iter)=Eall
@@ -224,11 +224,11 @@ Program main
   call psi_rho_GS
   call Hartree
 ! yabana
-  call Exc_Cor('GS',NBoccmax,zu_t)
+  call Exc_Cor(calc_mode_gs,NBoccmax,zu_t)
 ! yabana
   Vloc(1:NL)=Vh(1:NL)+Vpsl(1:NL)+Vexc(1:NL)
   Vloc_GS(:)=Vloc(:)
-  call Total_Energy_omp(Rion_update,'GS')
+  call Total_Energy_omp(Rion_update,calc_mode_gs)
   Eall0=Eall
   if(comm_is_root(1)) write(*,*) 'Eall =',Eall
 
@@ -311,7 +311,7 @@ Program main
 !reentrance
 2 if (entrance_option == 'reentrance') then
     position_option='asis'
-    if (MD_option /= 'Y') Rion_update = 'off'
+    if (MD_option /= 'Y') Rion_update = rion_update_off
   else
     position_option='rewind'
     entrance_iter=-1
@@ -385,15 +385,15 @@ Program main
       javt(iter,:)=jav(:)
       if (MD_option == 'Y') then
 !$acc update self(zu)
-        call Ion_Force_omp(Rion_update,'RT',ixy_m)
+        call Ion_Force_omp(Rion_update,calc_mode_rt,ixy_m)
         if (mod(iter, Nstep_write) == 0) then
-          call Total_Energy_omp(Rion_update,'RT',ixy_m)
+          call Total_Energy_omp(Rion_update,calc_mode_rt,ixy_m)
         end if
       else
         if (mod(iter, Nstep_write) == 0) then
 !$acc update self(zu)
-          call Total_Energy_omp(Rion_update,'RT',ixy_m)
-          call Ion_Force_omp(Rion_update,'RT',ixy_m)
+          call Total_Energy_omp(Rion_update,calc_mode_rt,ixy_m)
+          call Ion_Force_omp(Rion_update,calc_mode_rt,ixy_m)
         end if
       end if
     

--- a/modules/global_variables.f90
+++ b/modules/global_variables.f90
@@ -227,6 +227,15 @@ Module Global_Variables
   logical :: need_backup      = .FALSE.
 
 
+  ! calculation mode
+  integer, parameter :: calc_mode_gs = 1000
+  integer, parameter :: calc_mode_rt = 1100
+
+  ! Rion update flag
+  logical, parameter :: rion_update_on  = .true.
+  logical, parameter :: rion_update_off = .false.
+
+
 #if defined(__KNC__) || defined(__AVX512F__)
 # define MEM_ALIGNED 64
 #else


### PR DESCRIPTION
I improved a reverted PR #124.

I replaced dummy argument type `character(*)` to `integer`, because these arguments are induced to bugs.
If dummy character argument length is not matched to actual argument, character comparison gets unexpected behavior.

# Example

```Fortran
program string_comparision_test
  implicit none
  character(3) :: str
  str = 'on'
  call check(str)
  call check('on')
end program

subroutine check(str)
  implicit none
  character(3) :: str
  if (str == 'on') then
    print *, 'yes'
  else
    print *, 'no'
  end if
end subroutine
```

## Expected results
```
 % f95 ./test.f90
 % ./a.out
 yes
 yes
```

## Actual results
```
 % f95 ./test.f90
 % ./a.out
 yes
 no
```